### PR TITLE
Report accuracy for small prior-bout bins

### DIFF
--- a/elote/arenas/base.py
+++ b/elote/arenas/base.py
@@ -1,5 +1,6 @@
 import abc
 import math
+import numbers
 import random
 from typing import Dict, Any, List, Tuple, Optional
 
@@ -560,11 +561,19 @@ class History:
         Args:
             arena (BaseArena): The arena containing the competitors and their history
             thresholds (tuple, optional): Tuple of (lower_threshold, upper_threshold) for predictions
-            bin_size (int): Size of bins for grouping bout counts
+            bin_size (int): Size of bins for grouping bout counts. Must be a positive integer.
 
         Returns:
-            dict: A dictionary with 'binned' key containing binned accuracy data
+            dict: A dictionary with 'binned' key containing binned accuracy data. Every
+            non-empty bin reports its observed ``correct / total`` accuracy, however few
+            bouts it holds.
+
+        Raises:
+            ValueError: If ``bin_size`` is not a positive integer.
         """
+        if isinstance(bin_size, bool) or not isinstance(bin_size, numbers.Integral) or bin_size <= 0:
+            raise ValueError(f"bin_size must be a positive integer, got {bin_size!r}")
+
         # Default thresholds if not provided
         if thresholds is None:
             lower_threshold, upper_threshold = 0.5, 0.5
@@ -658,12 +667,11 @@ class History:
 
         # Calculate average accuracy for each bin
         for bin_idx, bin_data in binned_data.items():
-            if bin_data["total"] > 10:
+            if bin_data["total"] > 0:
                 bin_data["accuracy"] = bin_data["accuracy_sum"] / bin_data["total"]
-                del bin_data["accuracy_sum"]
             else:
                 bin_data["accuracy"] = None
-                del bin_data["accuracy_sum"]
+            del bin_data["accuracy_sum"]
 
             # Add bin range information
             bin_data["min_bouts"] = bin_idx * bin_size

--- a/tests/test_history_metrics.py
+++ b/tests/test_history_metrics.py
@@ -548,8 +548,6 @@ class TestAccuracyByPriorBouts(unittest.TestCase):
         expected = eval_history.calculate_metrics()["accuracy"]
         self.assertGreater(expected, 0.5)
 
-        # bin_size=25 keeps every bin above the method's own reporting floor of 10 bouts,
-        # so the weighted mean covers the whole history.
         binned = eval_history.accuracy_by_prior_bouts(arena, bin_size=25)["binned"]
         self.assertGreater(len(binned), 1)
         self.assertTrue(all(bin_data["accuracy"] is not None for bin_data in binned.values()))
@@ -559,6 +557,103 @@ class TestAccuracyByPriorBouts(unittest.TestCase):
 
         self.assertEqual(total, len(eval_history.bouts))
         self.assertAlmostEqual(weighted / total, expected)
+
+
+class _ExplodingArena:
+    """An arena whose history must never be read, so eager validation is provable."""
+
+    @property
+    def history(self):
+        raise AssertionError("bin_size must be validated before any bout is processed")
+
+
+def _history_with_leading_misses(count, misses):
+    """``count`` bouts between one pair, the first ``misses`` of them predicted wrong."""
+    history = History()
+    for index in range(count):
+        history.add_bout(Bout("a", "b", 0.9, "loss" if index < misses else "win"))
+    return history
+
+
+class TestAccuracyByPriorBoutsSmallBins(unittest.TestCase):
+    """Every non-empty bin reports its observed accuracy, however few bouts it holds."""
+
+    def test_single_bout_bin_reports_its_observed_accuracy(self):
+        """One bout is enough to report ``correct / total``."""
+        arena = MockArena()
+
+        hit = _history_with_leading_misses(1, 0).accuracy_by_prior_bouts(arena, bin_size=100)["binned"]
+        miss = _history_with_leading_misses(1, 1).accuracy_by_prior_bouts(arena, bin_size=100)["binned"]
+
+        self.assertEqual(hit[0]["total"], 1)
+        self.assertEqual(hit[0]["accuracy"], 1.0)
+        self.assertEqual(miss[0]["total"], 1)
+        self.assertEqual(miss[0]["accuracy"], 0.0)
+
+    def test_accuracy_is_continuous_across_the_former_eleven_bout_floor(self):
+        """Bins of 1 through 11 bouts all report the exact observed ratio.
+
+        The old code returned ``None`` for every total of 10 or fewer, so a bin jumped
+        from missing to rated on the eleventh bout.
+        """
+        arena = MockArena()
+
+        for count in range(1, 12):
+            with self.subTest(count=count):
+                binned = _history_with_leading_misses(count, 1).accuracy_by_prior_bouts(arena, bin_size=100)["binned"]
+
+                self.assertEqual(binned[0]["total"], count)
+                self.assertAlmostEqual(binned[0]["accuracy"], (count - 1) / count)
+
+    def test_weighted_bins_aggregate_across_prior_bout_counts(self):
+        """A bin spanning several prior-bout counts reports their combined ratio."""
+        arena = MockArena()
+
+        # Ten bouts between one pair, so each prior-bout count 0-9 holds exactly one bout.
+        # bin_size=5 groups counts 0-4 and 5-9 into two five-bout bins.
+        binned = _history_with_leading_misses(10, 2).accuracy_by_prior_bouts(arena, bin_size=5)["binned"]
+
+        self.assertEqual(sorted(binned), [0, 1])
+        self.assertEqual((binned[0]["min_bouts"], binned[0]["max_bouts"]), (0, 4))
+        self.assertEqual((binned[1]["min_bouts"], binned[1]["max_bouts"]), (5, 9))
+        self.assertEqual(binned[0]["total"], 5)
+        self.assertEqual(binned[1]["total"], 5)
+        self.assertAlmostEqual(binned[0]["accuracy"], 3 / 5)
+        self.assertAlmostEqual(binned[1]["accuracy"], 1.0)
+
+        total = sum(bin_data["total"] for bin_data in binned.values())
+        weighted = sum(bin_data["accuracy"] * bin_data["total"] for bin_data in binned.values())
+        self.assertAlmostEqual(weighted / total, 8 / 10)
+
+    def test_bins_weight_prior_bout_counts_by_their_bout_totals(self):
+        """A bin is the combined ``correct / total``, not the mean of its counts' accuracies.
+
+        The four fresh pairs land on prior-bout count 0 and the repeat lands on count 1,
+        so an unweighted mean over the two counts would report 0.625 instead of 0.4.
+        """
+        arena = MockArena()
+        history = History()
+        history.add_bout(Bout("p0", "q0", 0.9, "win"))
+        for index in range(1, 4):
+            history.add_bout(Bout("p%d" % index, "q%d" % index, 0.9, "loss"))
+        history.add_bout(Bout("p0", "q0", 0.9, "win"))
+
+        binned = history.accuracy_by_prior_bouts(arena, bin_size=5)["binned"]
+
+        self.assertEqual(sorted(binned), [0])
+        self.assertEqual(binned[0]["total"], 5)
+        self.assertAlmostEqual(binned[0]["accuracy"], 2 / 5)
+
+    def test_invalid_bin_sizes_are_rejected_before_any_bout_is_read(self):
+        """Zero, negative, non-integral and boolean bin sizes raise eagerly."""
+        history = _history_with_leading_misses(4, 1)
+
+        for bin_size in (0, -1, -5, 2.5, 5.0, True, False, "5", None):
+            with self.subTest(bin_size=bin_size):
+                with self.assertRaises(ValueError) as caught:
+                    history.accuracy_by_prior_bouts(_ExplodingArena(), bin_size=bin_size)
+
+                self.assertIn("bin_size must be a positive integer", str(caught.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import tempfile
 import matplotlib.pyplot as plt
+from elote.arenas.base import Bout, History
 from elote.visualization import (
     plot_rating_system_comparison,
     plot_optimized_accuracy_comparison,
@@ -122,6 +123,25 @@ class TestVisualization(unittest.TestCase):
         self.assertEqual(fig.get_figwidth(), 12)
         self.assertEqual(fig.get_figheight(), 8)
         self.assertEqual(fig.axes[0].get_title(), "Custom Title")
+
+    def test_plot_accuracy_by_prior_bouts_plots_small_bins(self):
+        """A bin holding only a handful of bouts is plotted, not dropped as missing."""
+
+        class _EmptyArena:
+            history = History()
+
+        history = History()
+        for index in range(5):
+            history.add_bout(Bout("a", "b", 0.9, "loss" if index == 0 else "win"))
+
+        binned = history.accuracy_by_prior_bouts(_EmptyArena(), bin_size=100)["binned"]
+        self.assertEqual(binned[0]["total"], 5)
+        self.assertAlmostEqual(binned[0]["accuracy"], 0.8)
+
+        fig = plot_accuracy_by_prior_bouts({"System A": {"binned": binned}})
+
+        (line,) = fig.axes[0].lines
+        self.assertEqual(list(line.get_ydata()), [0.8])
 
     def test_plot_accuracy_by_prior_bouts_with_empty_data(self):
         """Test that plot_accuracy_by_prior_bouts handles empty data gracefully."""


### PR DESCRIPTION
Closes #147

## What changed

`History.accuracy_by_prior_bouts` computed exact per-count accuracy and then threw usable results away: the hardcoded `if bin_data["total"] > 10` branch replaced any bin of 10 or fewer bouts with `accuracy: None`, so it vanished from `plot_accuracy_by_prior_bouts`. On `master`, ten correctly predicted bouts with `bin_size=100` returned `{0: {"total": 10, "accuracy": None, ...}}`, and one more identical bout flipped the same bin to `1.0`.

- `elote/arenas/base.py` — every non-empty bin now reports its observed `correct / total`. The weighted bin calculation and the result shape (`accuracy`, `total`, `min_bouts`, `max_bouts`) are unchanged; only the reporting floor is gone. The `else` branch still yields `None`, so an empty bin keeps its documented shape.
- `elote/arenas/base.py` — `bin_size` is validated eagerly, before any bout is read: zero, negative, non-integral and boolean values raise `ValueError("bin_size must be a positive integer, got …")` rather than leaking `ZeroDivisionError` from `count // bin_size` or silently producing float bin keys. The check uses `numbers.Integral`, so numpy integer bin sizes are accepted and `5.0` is not.
- Tests in `tests/test_history_metrics.py` (`TestAccuracyByPriorBoutsSmallBins`) assert exact values for a one-bout bin, for every total from 1 through 11 across the old boundary, for weighted aggregation across prior-bout counts, and for the rejected bin sizes.
- `tests/test_visualization.py` builds a real five-bout bin through `accuracy_by_prior_bouts` and asserts the plotted line's y-data is `[0.8]` — previously that bin was `None` and would have been plotted as missing.

Consumers that filtered on `accuracy is None` to mean "too few observations" now receive the measured value instead. The docstring states the new contract.

## Verification

`env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py`

- base (`5f180eb`, via `git stash`): **461 passed, 6 skipped**
- this branch: **467 passed, 6 skipped**

`env -u VIRTUAL_ENV uv run --extra dev ruff check .` → `All checks passed!`
`ruff format --check` on the three changed files → `3 files already formatted`

### Mutation testing (the new tests are not vacuous)

Each mutation applied to `elote/arenas/base.py`, the mutated line grepped to confirm it landed, `PYTHONDONTWRITEBYTECODE=1` set, then restored from a copy and the control re-run.

| Mutation | Result |
| --- | --- |
| Reinstate `if bin_data["total"] > 10:` (the original bug) | 5 failed — `test_single_bout_bin_reports_its_observed_accuracy`, `test_accuracy_is_continuous_across_the_former_eleven_bout_floor`, `test_weighted_bins_aggregate_across_prior_bout_counts`, `test_bins_weight_prior_bout_counts_by_their_bout_totals`, and the visualization test |
| Delete the `bin_size` validation | 1 failed — `test_invalid_bin_sizes_are_rejected_before_any_bout_is_read` |
| Plausible wrong fix: average the per-count accuracies instead of weighting by bout totals | 2 failed — `test_bins_weight_prior_bout_counts_by_their_bout_totals` and the existing `test_arena_driven_bins_agree_with_calculate_metrics` |
| Control (restored) | 32 passed (the two touched test files) |

The third mutation is why `test_bins_weight_prior_bout_counts_by_their_bout_totals` exists separately: in the simple ten-bout fixture every prior-bout count holds exactly one bout, so a weighted and an unweighted mean agree and `test_weighted_bins_aggregate_across_prior_bout_counts` passes on the wrong implementation. The dedicated fixture puts four bouts on count 0 and one on count 1, where the two differ (0.4 vs 0.625).

Validation eagerness is proved rather than assumed: the invalid-`bin_size` test passes an arena whose `history` property raises `AssertionError`, so the `ValueError` can only be reached if nothing touched the arena or the bouts first.

### Acceptance checklist

- [x] Every non-empty bin has numeric `accuracy`, including totals from 1 through 10
- [x] Small-bin fixtures assert exact `correct / total` values
- [x] Weighted aggregation equals the combined `correct / total` ratio
- [x] Zero, negative, non-integral and boolean `bin_size` raise `ValueError` before processing bouts
- [x] `plot_accuracy_by_prior_bouts` includes small bins with numeric accuracy
- [x] The suite passes