### PR TITLE
Reject invalid outcomes across bulk arena APIs

### DIFF
--- a/elote/arenas/lambda_arena.py
+++ b/elote/arenas/lambda_arena.py
@@ -9,6 +9,11 @@ from elote.logging import logger
 
 
 class LambdaArena(BaseArena):
+    @staticmethod
+    def _validate_outcome(outcome: Optional[float]) -> None:
+        if outcome is not None and outcome not in (1.0, 0.0, 0.5):
+            raise ValueError(f"outcome must be one of 1.0, 0.0 or 0.5, got {outcome!r}")
+
     def __init__(
         self,
         func: Callable[..., Optional[bool]],
@@ -126,8 +131,7 @@ class LambdaArena(BaseArena):
                 ``scores`` is supplied without ``outcome``, or if ``scores`` is malformed,
                 negative, non-finite, or disagrees with ``outcome``.
         """
-        if outcome is not None and outcome not in (1.0, 0.0, 0.5):
-            raise ValueError(f"outcome must be one of 1.0, 0.0 or 0.5, got {outcome!r}")
+        self._validate_outcome(outcome)
         if scores is not None and outcome is None:
             raise ValueError("scores requires an explicit outcome so the two can be checked for agreement")
         # Validated before any competitor is created or any history is recorded, so a bad
@@ -249,6 +253,7 @@ class LambdaArena(BaseArena):
         skipped_bouts = 0
         logger.info("Processing %d bouts for training history", total_bouts)
         for i, (a, b, outcome) in enumerate(iterator):
+            self._validate_outcome(outcome)
             # Get or create competitors
             c_a = self._get_or_create_competitor(a)
             c_b = self._get_or_create_competitor(b)
@@ -290,6 +295,7 @@ class LambdaArena(BaseArena):
         skipped_bouts = 0
         logger.info("Evaluating performance using %d bouts", total_bouts)
         for i, (a, b, outcome) in enumerate(iterator):
+            self._validate_outcome(outcome)
             # Evaluation is a read: an identifier the arena never trained on has no
             # rating to evaluate, so the bout is skipped rather than scored against a
             # freshly defaulted competitor.
@@ -340,6 +346,7 @@ class LambdaArena(BaseArena):
         skipped_bouts = 0
         logger.info("Validating model using %d bouts", total_bouts)
         for i, (a, b, outcome) in enumerate(iterator):
+            self._validate_outcome(outcome)
             # Validation is a read: an identifier the arena never trained on has no
             # rating to validate, so the bout is skipped rather than scored against a
             # freshly defaulted competitor.

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -282,6 +282,18 @@ class TestArenas(unittest.TestCase):
         arena.process_history(bouts, progress_bar=False)
         self.assertEqual(len(arena.history.bouts), 1)
 
+    def test_process_history_rejects_invalid_outcome_without_side_effects(self):
+        arena = LambdaArena(func=lambda x, y: True)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"^outcome must be one of 1\.0, 0\.0 or 0\.5, got 0\.25$",
+        ):
+            arena.process_history([("x", "y", 0.25)], progress_bar=False)
+
+        self.assertEqual(arena.competitors, {})
+        self.assertEqual(arena.history.bouts, [])
+
     def test_evaluate_performance_non_colley_competitors(self):
         """evaluate_performance should run end-to-end for non-Colley competitors."""
         for competitor_cls in (EloCompetitor, GlickoCompetitor):
@@ -313,6 +325,27 @@ class TestArenas(unittest.TestCase):
                 # validate only records predictions; it must not update ratings.
                 ratings_after = {cid: c.rating for cid, c in arena.competitors.items()}
                 self.assertEqual(ratings_before, ratings_after)
+
+    def test_evaluation_and_validation_reject_invalid_outcomes_without_side_effects(self):
+        for method_name, invalid_outcome, history_name in (
+            ("evaluate_performance", 7.0, "eval_history"),
+            ("validate", -1.0, "validation_history"),
+        ):
+            with self.subTest(method=method_name):
+                arena = LambdaArena(func=lambda x, y: True)
+                arena.process_history([("x", "y", 1.0)], progress_bar=False)
+                population_before = {cid: c.rating for cid, c in arena.competitors.items()}
+                training_history_before = list(arena.history.bouts)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    rf"^outcome must be one of 1\.0, 0\.0 or 0\.5, got {invalid_outcome}$",
+                ):
+                    getattr(arena, method_name)([("x", "y", invalid_outcome)], progress_bar=False)
+
+                self.assertEqual({cid: c.rating for cid, c in arena.competitors.items()}, population_before)
+                self.assertEqual(arena.history.bouts, training_history_before)
+                self.assertEqual(getattr(arena, history_name).bouts, [])
 
 
 class TestArenaEvaluationSkipsUnknownCompetitors(unittest.TestCase):


### PR DESCRIPTION
Closes #146

## Summary

- centralize the arena outcome contract in one validator used by matchup and all bulk APIs
- reject invalid bulk rows before competitor creation, rating changes, predictions, or history writes
- add regression coverage proving training, evaluation, and validation rejection is side-effect-free

## Verification

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` — 463 passed, 6 skipped
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` — passed
- `git diff --check` — passed
- Mutation check: removed the three bulk validator calls; both focused regression tests failed, then passed again after restoration
