### PR TITLE
Add Whole-History Rating competitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 v1.2.1
 ======
 
+New rating systems
+
+ * Added Whole-History Rating (`WholeHistoryRatingCompetitor`), a lazy, bounded time-aware
+   Bradley-Terry MAP system with a queryable per-playing-day rating curve.
+
 A correctness release. Every shipped rating system except Elo, DWZ, Colley and Bradley-Terry had at
 least one numeric defect, and the prediction-quality metrics silently discarded drawn bouts. Ratings
 and predicted probabilities produced by this version differ from v1.2.0; state exported by v1.2.0

--- a/docs/source/api/competitors.rst
+++ b/docs/source/api/competitors.rst
@@ -111,6 +111,15 @@ Bradley-Terry Competitor
    :show-inheritance:
    :special-members: __init__
 
+Whole-History Rating Competitor
+-------------------------------
+
+.. automodule:: elote.competitors.whr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+
 Blended Competitor
 -----------------
 
@@ -118,4 +127,4 @@ Blended Competitor
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members: __init__ 
+   :special-members: __init__

--- a/docs/source/competitors.rst
+++ b/docs/source/competitors.rst
@@ -67,6 +67,12 @@ Bradley-Terry Competitor
 .. autoclass:: elote.competitors.bradley_terry.BradleyTerryCompetitor
     :members: export_state,expected_score,beat,tied,rating,to_json,from_json
 
+Whole-History Rating Competitor
+-------------------------------
+
+.. autoclass:: elote.competitors.whr.WholeHistoryRatingCompetitor
+    :members: export_state,expected_score,beat,tied,rating,rating_at,rating_history,to_json,from_json
+
 BlendedCompetitor
 -----------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,6 +49,7 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
    rating_systems/keener
    rating_systems/pythagorean
    rating_systems/bradley_terry
+   rating_systems/whr
    rating_systems/ensemble
    rating_systems/comparison
 

--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -82,6 +82,12 @@ Overview Comparison
      - No
      - Yes
      - Maximum-likelihood ranking
+   * - **Whole-History Rating**
+     - Coulom (2008)
+     - High
+     - No
+     - Yes
+     - Time-varying strength curves
    * - **Ensemble**
      - Meta-system
      - High
@@ -91,7 +97,7 @@ Overview Comparison
 
 Online systems (Elo, Glicko, Glicko-2, TrueSkill, ECF, DWZ, Pythagorean) update ratings
 incrementally after each result. Global-fit systems (Colley Matrix, Massey, Keener and
-Bradley-Terry) re-solve the whole connected group of competitors from the full set of results,
+Bradley-Terry and Whole-History Rating) fit the whole connected group from the full set of results,
 which makes them order independent. Pythagorean is order independent too, for a different reason:
 its state is a running sum of points that ignores the opponent graph entirely. Massey, Keener and
 Pythagorean are the three that read the optional score payload; the rest use only who beat whom.
@@ -127,6 +133,8 @@ Mathematical Formulation
      - :math:`w = \frac{PF^{k}}{PF^{k} + PA^{k}}` on prior-adjusted point totals; :math:`E_A = \frac{w_A - w_A w_B}{w_A + w_B - 2 w_A w_B}` (log5)
    * - **Bradley-Terry**
      - :math:`P(A \text{ beats } B) = \frac{p_A}{p_A + p_B} = \frac{1}{1 + e^{-(\beta_A - \beta_B)}}`
+   * - **Whole-History Rating**
+     - Bradley-Terry likelihood per game plus :math:`r_{t+1}-r_t \sim N(0, w^2\Delta t)`
    * - **Ensemble**
      - :math:`E_{ensemble} = \sum_{i=1}^{n} w_i \times E_i` where :math:`w_i` are weights
 
@@ -161,6 +169,8 @@ Key Parameters
      - Exponent (default 2.37), Prior points (default 1.0); no initial rating
    * - **Bradley-Terry**
      - Initial rating, Scale, Regularization, Max iterations
+   * - **Whole-History Rating**
+     - Per-day variance (w2), Initial rating, Max iterations, Precision
    * - **Ensemble**
      - Component systems, Weights
 
@@ -335,6 +345,21 @@ Bradley-Terry
 - The match graph cannot be serialized (only aggregate counts)
 - More expensive than Elo for very large populations
 
+Whole-History Rating
+^^^^^^^^^^^^^^^^^^^^
+
+**Strengths:**
+- Estimates a queryable rating curve rather than one lifetime strength
+- Later evidence revises earlier ratings
+- Time gaps explicitly control how freely strength can move
+- Lazy, bounded fitting avoids optimizing after every result
+
+**Weaknesses:**
+- More computationally expensive than a single-rating model
+- Requires meaningful timestamps for the time curve
+- The opponent graph cannot be serialized; continued play starts a fresh history
+- Provides no separate uncertainty estimate
+
 Ensemble
 ^^^^^^^^
 
@@ -367,7 +392,8 @@ Consider the following factors when choosing a rating system:
    - General purpose: Elo or Glicko
 
 3. **Order Independence**: Do you need a ranking that ignores schedule order?
-   - Yes: Colley Matrix, Massey, Keener, Bradley-Terry, or Pythagorean
+   - Yes: Colley Matrix, Massey, Keener, Bradley-Terry, Whole-History Rating, or Pythagorean
+   - Yes, and historical strength matters: Whole-History Rating
    - Yes, and you have real scores: Massey (linear margin), Keener (bounded score share), or
      Pythagorean (points ratio, no strength of schedule)
    - No: any other online system (Elo, Glicko, etc.)
@@ -403,6 +429,7 @@ Here's a quick comparison of how to use each system in Elote:
         KeenerCompetitor,
         PythagoreanCompetitor,
         BradleyTerryCompetitor,
+        WholeHistoryRatingCompetitor,
         BlendedCompetitor,
     )
 
@@ -438,6 +465,9 @@ Here's a quick comparison of how to use each system in Elote:
 
     # Bradley-Terry (Elo-compatible scale)
     bt_player = BradleyTerryCompetitor(initial_rating=1500)
+
+    # Whole-History Rating (time-aware Elo-compatible curve)
+    whr_player = WholeHistoryRatingCompetitor(w2=300.0)
 
     # Ensemble (blend of sub-competitors)
     ensemble_player = BlendedCompetitor(

--- a/docs/source/rating_systems/whr.rst
+++ b/docs/source/rating_systems/whr.rst
@@ -1,0 +1,34 @@
+Whole-History Rating
+====================
+
+Whole-History Rating (WHR) is a time-aware Bradley-Terry model. It estimates one
+rating for each day on which a competitor played and links consecutive ratings with
+a Wiener-process prior. Later results can therefore revise earlier ratings while the
+curve remains smoother when games are close together.
+
+.. code-block:: python
+
+   from datetime import datetime
+   from elote import WholeHistoryRatingCompetitor
+
+   alice = WholeHistoryRatingCompetitor(w2=300.0)
+   bob = WholeHistoryRatingCompetitor(w2=300.0)
+   alice.beat(bob, match_time=datetime(2025, 1, 10))
+   print(alice.rating)
+   print(alice.rating_at(datetime(2025, 1, 10)))
+   print(alice.rating_history())
+
+Fitting is lazy: results mark the connected component dirty, while ``rating``,
+``rating_at``, ``rating_history`` and ``expected_score`` trigger at most
+``max_iterations`` Newton sweeps. ``precision`` controls the Elo-point convergence
+tolerance. Lower values cost more but give a tighter fit.
+
+``w2`` is the per-day variance in Elo points squared. A larger value permits faster
+rating movement between playing days; a smaller value makes the curve smoother.
+
+Reference
+---------
+
+Coulom, R. (2008). *Whole-History Rating: A Bayesian Rating System for Players of
+Time-Varying Strength*.
+

--- a/elote/__init__.py
+++ b/elote/__init__.py
@@ -29,6 +29,7 @@ Available rating systems:
 - Keener: A score-based rating system built on the dominant eigenvector of a preference matrix
 - Pythagorean: A points-based win expectation derived from points scored and allowed
 - Bradley-Terry: A maximum-likelihood paired-comparison model
+- Whole-History Rating: A time-aware Bradley-Terry model that estimates rating curves
 - Ensemble: A meta-rating system that combines multiple rating systems
 
 Datasets (require optional dependencies):
@@ -53,6 +54,7 @@ from elote.competitors.massey import MasseyCompetitor
 from elote.competitors.keener import KeenerCompetitor
 from elote.competitors.pythagorean import PythagoreanCompetitor
 from elote.competitors.bradley_terry import BradleyTerryCompetitor
+from elote.competitors.whr import WholeHistoryRatingCompetitor
 from elote.competitors.ensemble import BlendedCompetitor
 
 # Core arenas - always available
@@ -91,6 +93,7 @@ __all__ = [
     "KeenerCompetitor",
     "PythagoreanCompetitor",
     "BradleyTerryCompetitor",
+    "WholeHistoryRatingCompetitor",
     "BlendedCompetitor",
     # Arenas
     "LambdaArena",

--- a/elote/competitors/whr.py
+++ b/elote/competitors/whr.py
@@ -1,0 +1,339 @@
+"""Whole-History Rating (WHR) for time-aware paired comparisons."""
+
+import math
+from datetime import date, datetime
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Set, Tuple, Type, TypeVar, cast
+
+import numpy as np
+
+from elote.competitors.base import BaseCompetitor, InvalidParameterException
+
+T = TypeVar("T", bound="WholeHistoryRatingCompetitor")
+
+
+class WholeHistoryRatingCompetitor(BaseCompetitor):
+    """A time-aware Bradley-Terry maximum-a-posteriori rating curve.
+
+    One latent rating is kept for every distinct playing day. Consecutive ratings are
+    linked by a Wiener-process prior whose variance is ``w2 * elapsed_days`` in Elo
+    points squared. Results use the Bradley-Terry likelihood, and a bounded sequence
+    of per-competitor tridiagonal Newton updates fits the connected component lazily.
+
+    Serialized state preserves the fitted per-day curve and day index, but cannot
+    preserve object references in the game graph. On the first result after restore,
+    the latest restored rating becomes the initial rating of a fresh history; restored
+    lifetime games are therefore never silently combined with a reset graph.
+
+    Args:
+        w2: Per-day Wiener-process variance in Elo points squared.
+        initial_rating: Rating before any games, on the Elo scale.
+        max_iterations: Maximum component-wide Newton sweeps per lazy fit.
+        precision: Stop when the largest Elo-scale Newton step is below this value.
+
+    Reference: Coulom, R. (2008), *Whole-History Rating: A Bayesian Rating System
+    for Players of Time-Varying Strength*.
+    """
+
+    _minimum_rating: ClassVar[float] = 0.0
+    _scale: ClassVar[float] = 400.0 / math.log(10.0)
+    _default_w2: ClassVar[float] = 300.0
+    _default_initial_rating: ClassVar[float] = 1500.0
+    _default_max_iterations: ClassVar[int] = 20
+    _default_precision: ClassVar[float] = 0.1
+
+    def __init__(
+        self,
+        w2: Optional[float] = None,
+        initial_rating: Optional[float] = None,
+        max_iterations: Optional[int] = None,
+        precision: Optional[float] = None,
+    ) -> None:
+        super().__init__()
+        w2 = self._default_w2 if w2 is None else w2
+        initial_rating = self._default_initial_rating if initial_rating is None else initial_rating
+        max_iterations = self._default_max_iterations if max_iterations is None else max_iterations
+        precision = self._default_precision if precision is None else precision
+        self._validate_parameters(w2, initial_rating, max_iterations, precision)
+        self._w2 = float(w2)
+        self._initial_rating = float(initial_rating)
+        self._max_iterations = int(max_iterations)
+        self._precision = float(precision)
+        self._days: List[date] = []
+        self._ratings: List[float] = []
+        self._day_index: Dict[date, int] = {}
+        self._games: List[List[Tuple["WholeHistoryRatingCompetitor", date, float]]] = []
+        self._opponents: Set["WholeHistoryRatingCompetitor"] = set()
+        self._dirty = False
+        self._restored = False
+        self._last_activity: Optional[datetime] = None
+
+    @staticmethod
+    def _validate_parameters(w2: float, initial_rating: float, max_iterations: int, precision: float) -> None:
+        if not math.isfinite(w2) or w2 <= 0:
+            raise InvalidParameterException("w2 must be positive and finite")
+        if not math.isfinite(initial_rating):
+            raise InvalidParameterException("initial_rating must be finite")
+        if isinstance(max_iterations, bool) or not isinstance(max_iterations, int) or max_iterations < 1:
+            raise InvalidParameterException("max_iterations must be a positive integer")
+        if not math.isfinite(precision) or precision <= 0:
+            raise InvalidParameterException("precision must be positive and finite")
+
+    @property
+    def rating(self) -> float:
+        self._ensure_fit()
+        return self._ratings[-1] if self._ratings else self._initial_rating
+
+    @rating.setter
+    def rating(self, value: float) -> None:
+        if not math.isfinite(value):
+            raise InvalidParameterException("rating must be finite")
+        if self._ratings:
+            self._ratings[-1] = float(value)
+        else:
+            self._initial_rating = float(value)
+
+    @property
+    def num_games(self) -> int:
+        return sum(len(games) for games in self._games)
+
+    def rating_at(self, when: datetime | date) -> float:
+        """Return the fitted rating on, or most recently before, ``when``."""
+        self._ensure_fit()
+        day = when.date() if isinstance(when, datetime) else when
+        candidates = [i for i, played in enumerate(self._days) if played <= day]
+        return self._initial_rating if not candidates else self._ratings[candidates[-1]]
+
+    def rating_history(self) -> List[Tuple[date, float]]:
+        """Return a chronological copy of the fitted ``(day, rating)`` curve."""
+        self._ensure_fit()
+        return list(zip(self._days, self._ratings, strict=True))
+
+    def expected_score(self, competitor: BaseCompetitor) -> float:
+        self.verify_competitor_types(competitor)
+        other = cast(WholeHistoryRatingCompetitor, competitor)
+        self._ensure_fit()
+        other._ensure_fit()
+        high, low = (self.rating, other.rating) if self.rating >= other.rating else (other.rating, self.rating)
+        numerator = math.exp((low - high) / self._scale)
+        high_probability = min(1.0 / (1.0 + numerator), math.nextafter(1.0, 0.0))
+        return high_probability if self.rating >= other.rating else 1.0 - high_probability
+
+    def beat(
+        self,
+        competitor: BaseCompetitor,
+        match_time: Optional[datetime] = None,
+        *,
+        scores: Optional[Sequence[float]] = None,
+    ) -> None:
+        self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 1.0)
+        self._record(cast(WholeHistoryRatingCompetitor, competitor), 1.0, match_time)
+
+    def lost_to(
+        self,
+        competitor: BaseCompetitor,
+        match_time: Optional[datetime] = None,
+        *,
+        scores: Optional[Sequence[float]] = None,
+    ) -> None:
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 0.0)
+        competitor.beat(
+            self,
+            match_time,
+            scores=None if validated is None else (validated[1], validated[0]),
+        )
+
+    def tied(
+        self,
+        competitor: BaseCompetitor,
+        match_time: Optional[datetime] = None,
+        *,
+        scores: Optional[Sequence[float]] = None,
+    ) -> None:
+        self.verify_competitor_types(competitor)
+        self._validate_scores(scores, 0.5)
+        self._record(cast(WholeHistoryRatingCompetitor, competitor), 0.5, match_time)
+
+    def _record(self, opponent: "WholeHistoryRatingCompetitor", score: float, when: Optional[datetime]) -> None:
+        if self._restored:
+            self._restart_from_restored_rating()
+        if opponent._restored:
+            opponent._restart_from_restored_rating()
+        timestamp = when or datetime.now()
+        day = timestamp.date()
+        own_index = self._node(day)
+        opponent_index = opponent._node(day)
+        self._games[own_index].append((opponent, day, score))
+        opponent._games[opponent_index].append((self, day, 1.0 - score))
+        self._opponents.add(opponent)
+        opponent._opponents.add(self)
+        self._last_activity = timestamp
+        opponent._last_activity = timestamp
+        for member in self._component():
+            member._dirty = True
+
+    def _restart_from_restored_rating(self) -> None:
+        latest = self._ratings[-1] if self._ratings else self._initial_rating
+        self._initial_rating = latest
+        self._days, self._ratings, self._games = [], [], []
+        self._day_index, self._opponents = {}, set()
+        self._restored = False
+
+    def _node(self, day: date) -> int:
+        if day in self._day_index:
+            return self._day_index[day]
+        rating = self._ratings[-1] if self._ratings else self._initial_rating
+        position = 0
+        while position < len(self._days) and self._days[position] < day:
+            position += 1
+        self._days.insert(position, day)
+        self._ratings.insert(position, rating)
+        self._games.insert(position, [])
+        self._day_index = {value: i for i, value in enumerate(self._days)}
+        return position
+
+    def _component(self) -> List["WholeHistoryRatingCompetitor"]:
+        result: List[WholeHistoryRatingCompetitor] = []
+        pending = [self]
+        seen: Set[WholeHistoryRatingCompetitor] = set()
+        while pending:
+            current = pending.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            result.append(current)
+            pending.extend(current._opponents - seen)
+        return result
+
+    def _ensure_fit(self) -> None:
+        component = self._component()
+        if not any(member._dirty for member in component):
+            return
+        for _ in range(self._max_iterations):
+            largest = 0.0
+            for member in component:
+                largest = max(largest, member._newton_update())
+            if largest < self._precision:
+                break
+        for member in component:
+            member._dirty = False
+
+    def _newton_update(self) -> float:
+        n = len(self._ratings)
+        if not n:
+            return 0.0
+        gradient = np.zeros(n)
+        diagonal = np.zeros(n)
+        off_diagonal = np.zeros(max(0, n - 1))
+        anchor_weight = 1.0 / self._w2
+        gradient[0] += (self._initial_rating - self._ratings[0]) * anchor_weight
+        diagonal[0] += anchor_weight
+        for i, games in enumerate(self._games):
+            for opponent, day, score in games:
+                opponent_rating = opponent._ratings[opponent._day_index[day]]
+                difference = (self._ratings[i] - opponent_rating) / self._scale
+                probability = 1.0 / (1.0 + math.exp(-max(-700.0, min(700.0, difference))))
+                gradient[i] += (score - probability) / self._scale
+                diagonal[i] += probability * (1.0 - probability) / (self._scale * self._scale)
+        for i in range(n - 1):
+            variance = self._w2 * (self._days[i + 1] - self._days[i]).days
+            weight = 1.0 / variance
+            difference = self._ratings[i + 1] - self._ratings[i]
+            gradient[i] += difference * weight
+            gradient[i + 1] -= difference * weight
+            diagonal[i] += weight
+            diagonal[i + 1] += weight
+            off_diagonal[i] = -weight
+        matrix = np.diag(diagonal)
+        if n > 1:
+            matrix += np.diag(off_diagonal, 1) + np.diag(off_diagonal, -1)
+        matrix += np.eye(n) * 1e-12
+        step = np.linalg.solve(matrix, gradient)
+        step = np.clip(step, -200.0, 200.0)
+        self._ratings = [rating + float(delta) for rating, delta in zip(self._ratings, step, strict=True)]
+        return float(np.max(np.abs(step)))
+
+    def _export_parameters(self) -> Dict[str, Any]:
+        return {
+            "w2": self._w2,
+            "initial_rating": self._initial_rating,
+            "max_iterations": self._max_iterations,
+            "precision": self._precision,
+        }
+
+    def _export_current_state(self) -> Dict[str, Any]:
+        self._ensure_fit()
+        return {
+            "rating": self.rating,
+            "days": [day.isoformat() for day in self._days],
+            "ratings": list(self._ratings),
+            "day_index": {day.isoformat(): index for day, index in self._day_index.items()},
+            "last_activity": self._last_activity.isoformat() if self._last_activity else None,
+        }
+
+    def _import_parameters(self, parameters: Dict[str, Any]) -> None:
+        self._w2 = float(parameters.get("w2", self._default_w2))
+        self._initial_rating = float(parameters.get("initial_rating", self._default_initial_rating))
+        self._max_iterations = int(parameters.get("max_iterations", self._default_max_iterations))
+        self._precision = float(parameters.get("precision", self._default_precision))
+
+    def _import_current_state(self, state: Dict[str, Any]) -> None:
+        self._days = [date.fromisoformat(value) for value in state.get("days", [])]
+        self._ratings = [float(value) for value in state.get("ratings", [])]
+        self._day_index = {day: i for i, day in enumerate(self._days)}
+        self._games = [[] for _ in self._days]
+        self._opponents = set()
+        value = state.get("last_activity")
+        self._last_activity = datetime.fromisoformat(value) if value else None
+        self._dirty = False
+        self._restored = bool(self._days)
+
+    @classmethod
+    def _create_from_parameters(cls: Type[T], parameters: Dict[str, Any]) -> T:
+        return cls(**parameters)
+
+    def reset(self) -> None:
+        self._days, self._ratings, self._games = [], [], []
+        self._day_index, self._opponents = {}, set()
+        self._dirty = self._restored = False
+        self._last_activity = None
+
+    @classmethod
+    def configure_class(cls, **kwargs: Any) -> None:
+        mapping = {
+            "w2": "_default_w2",
+            "initial_rating": "_default_initial_rating",
+            "max_iterations": "_default_max_iterations",
+            "precision": "_default_precision",
+        }
+        values = {key: kwargs.get(key, getattr(cls, name)) for key, name in mapping.items()}
+        cls._validate_parameters(**values)
+        for key, value in kwargs.items():
+            if key not in mapping:
+                raise InvalidParameterException(f"Unknown class parameter: {key}")
+            setattr(cls, mapping[key], value)
+
+    def configure(self, **kwargs: Any) -> None:
+        """Validate and update this instance's fitting parameters."""
+        allowed = {"w2", "initial_rating", "max_iterations", "precision"}
+        unknown = set(kwargs) - allowed
+        if unknown:
+            raise InvalidParameterException(f"Unknown instance parameter: {unknown.pop()}")
+        values = {
+            "w2": kwargs.get("w2", self._w2),
+            "initial_rating": kwargs.get("initial_rating", self._initial_rating),
+            "max_iterations": kwargs.get("max_iterations", self._max_iterations),
+            "precision": kwargs.get("precision", self._precision),
+        }
+        self._validate_parameters(**values)
+        self._w2 = float(values["w2"])
+        self._initial_rating = float(values["initial_rating"])
+        self._max_iterations = int(values["max_iterations"])
+        self._precision = float(values["precision"])
+        self._dirty = bool(self._days)
+
+    def __eq__(self, other: Any) -> bool:
+        return self is other
+
+    __hash__ = object.__hash__

--- a/tests/test_Arenas.py
+++ b/tests/test_Arenas.py
@@ -15,6 +15,7 @@ from elote import (
     LambdaArena,
     MasseyCompetitor,
     PythagoreanCompetitor,
+    WholeHistoryRatingCompetitor,
     TrueSkillCompetitor,
 )
 
@@ -452,6 +453,7 @@ class TestArenaStateRoundTrip(unittest.TestCase):
         MasseyCompetitor,
         KeenerCompetitor,
         PythagoreanCompetitor,
+        WholeHistoryRatingCompetitor,
     )
 
     # Colley, Massey, Bradley-Terry and Keener reset their opponent match graph on import by design

--- a/tests/test_benchmark_module.py
+++ b/tests/test_benchmark_module.py
@@ -10,6 +10,8 @@ from elote.competitors.colley import ColleyMatrixCompetitor
 from elote.competitors.massey import MasseyCompetitor
 from elote.competitors.keener import KeenerCompetitor
 from elote.competitors.pythagorean import PythagoreanCompetitor
+from elote.competitors.whr import WholeHistoryRatingCompetitor
+from elote.competitors.bradley_terry import BradleyTerryCompetitor
 from elote.arenas.base import History, Bout
 from elote.datasets.base import DataSplit
 from elote.datasets.synthetic import SyntheticDataset
@@ -521,6 +523,26 @@ class TestBenchmarkEndToEnd(unittest.TestCase):
         for entry in results:
             with self.subTest(system=entry["name"]):
                 self.assertGreater(entry["accuracy"], 0.5)
+
+    def test_whr_runs_end_to_end_and_can_be_compared(self):
+        result = evaluate_competitor(
+            competitor_class=WholeHistoryRatingCompetitor,
+            data_split=self.data_split,
+            comparison_function=_always_true,
+            optimize_thresholds=False,
+        )
+        self.assertGreater(result["accuracy"], 0.5)
+
+        results = benchmark_competitors(
+            [
+                {"class": WholeHistoryRatingCompetitor, "name": "WHR", "params": {}},
+                {"class": BradleyTerryCompetitor, "name": "Bradley-Terry", "params": {}},
+            ],
+            self.data_split,
+            _always_true,
+            optimize_thresholds=False,
+        )
+        self.assertEqual([entry["name"] for entry in results], ["WHR", "Bradley-Terry"])
 
 
 if __name__ == "__main__":

--- a/tests/test_score_channel.py
+++ b/tests/test_score_channel.py
@@ -23,6 +23,7 @@ from elote import (
     LambdaArena,
     MasseyCompetitor,
     PythagoreanCompetitor,
+    WholeHistoryRatingCompetitor,
     TrueSkillCompetitor,
     benchmark_competitors,
     train_arena_with_dataset,
@@ -46,6 +47,7 @@ COMPETITOR_CLASSES = (
     MasseyCompetitor,
     KeenerCompetitor,
     PythagoreanCompetitor,
+    WholeHistoryRatingCompetitor,
 )
 
 # A win, a draw and a loss, with the unit scores each result implies.

--- a/tests/test_unified_interface.py
+++ b/tests/test_unified_interface.py
@@ -12,6 +12,7 @@ from elote import (
     MasseyCompetitor,
     KeenerCompetitor,
     PythagoreanCompetitor,
+    WholeHistoryRatingCompetitor,
 )
 from elote.competitors.base import (
     MissMatchedCompetitorTypesException,
@@ -439,6 +440,7 @@ class TestExpectedScoreBounds(unittest.TestCase):
         MasseyCompetitor,
         KeenerCompetitor,
         PythagoreanCompetitor,
+        WholeHistoryRatingCompetitor,
     )
 
     # A lopsided run: long enough that a one-sided rating gap opens up, with

--- a/tests/test_whr.py
+++ b/tests/test_whr.py
@@ -1,0 +1,65 @@
+"""Known-value and defining-behaviour tests for Whole-History Rating."""
+
+import datetime
+import unittest
+
+from elote import WholeHistoryRatingCompetitor
+from elote.competitors.base import BaseCompetitor
+
+
+class TestWholeHistoryRating(unittest.TestCase):
+    def test_known_value_single_win(self):
+        """Reference: direct root of Coulom (2008) Eq. 4 likelihood plus Gaussian prior."""
+        winner = WholeHistoryRatingCompetitor(precision=1e-10, max_iterations=100)
+        loser = WholeHistoryRatingCompetitor(precision=1e-10, max_iterations=100)
+        winner.beat(loser, datetime.datetime(2020, 1, 1))
+
+        self.assertAlmostEqual(winner.rating, 1500.8591987719, places=7)
+        self.assertAlmostEqual(loser.rating, 1499.1408012281, places=7)
+
+    def test_known_value_two_wins_thirty_days_apart(self):
+        """Reference: independent dense-Hessian Newton solve of Coulom (2008) Eqs. 4-6."""
+        winner = WholeHistoryRatingCompetitor(precision=1e-10, max_iterations=100)
+        loser = WholeHistoryRatingCompetitor(precision=1e-10, max_iterations=100)
+        start = datetime.datetime(2020, 1, 1)
+        winner.beat(loser, start)
+        winner.beat(loser, start + datetime.timedelta(days=30))
+
+        self.assertAlmostEqual(winner.rating_at(start), 1501.6006622749, places=7)
+        self.assertAlmostEqual(winner.rating, 1523.9551256433, places=7)
+
+    def test_later_results_revise_past_rating(self):
+        start = datetime.datetime(2020, 1, 1)
+        a = WholeHistoryRatingCompetitor()
+        b = WholeHistoryRatingCompetitor()
+        a.beat(b, start)
+        before = a.rating_at(start)
+        for offset in range(1, 11):
+            a.beat(b, start + datetime.timedelta(days=offset * 10))
+
+        self.assertGreater(a.rating_at(start), before)
+
+    def test_long_lopsided_run_has_strict_exactly_complementary_probabilities(self):
+        a = WholeHistoryRatingCompetitor(w2=1e9)
+        b = WholeHistoryRatingCompetitor(w2=1e9)
+        for _ in range(60):
+            a.beat(b)
+        probability = a.expected_score(b)
+        reverse = b.expected_score(a)
+        self.assertGreater(probability, 0.0)
+        self.assertLess(probability, 1.0)
+        self.assertGreater(reverse, 0.0)
+        self.assertLess(reverse, 1.0)
+        self.assertEqual(probability + reverse, 1.0)
+
+    def test_state_preserves_curve_and_registry(self):
+        a = WholeHistoryRatingCompetitor()
+        b = WholeHistoryRatingCompetitor()
+        a.beat(b, datetime.datetime(2020, 1, 1))
+        restored = BaseCompetitor.from_state(a.export_state())
+        self.assertEqual(restored.rating_history(), a.rating_history())
+        self.assertIn("WholeHistoryRatingCompetitor", BaseCompetitor.list_competitor_types())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #145

## Summary

- add `WholeHistoryRatingCompetitor`, a time-aware Bradley-Terry MAP model with one Elo-scale latent rating per playing day and a Wiener-process prior between days
- fit dirty connected components lazily with bounded per-competitor tridiagonal Newton sweeps, configurable through `w2`, `max_iterations`, and `precision`
- expose `rating_at()` and `rating_history()`, forward arena timestamps through `_last_activity`, preserve strict/exactly-complementary probabilities, and support the common score, registry, reset, and serialization contracts
- preserve fitted curves across serialization while explicitly starting a fresh graph from the restored latest rating on continued play
- register WHR across the shared interface, arena persistence, score-channel, and benchmark tests and document it across the rating-system and API guides

## Numeric coverage

The known-value tests use direct evaluation of the Bradley-Terry likelihood, Gaussian first-rating prior, and Wiener transition terms from Coulom (2008). They pin a single-game two-player fit and a two-game/two-day fit to 1e-7 Elo points. Additional regressions assert that later results revise an already-fitted historical rating and that 60 one-sided results retain strict bounds and exact complementarity.

## Performance

Measured on a fixed schedule generated once with seed 145: 30 competitors, 300 timestamped matches, ten matches per playing day, followed by leaderboard materialization. Each system ran the identical schedule five times on the same machine.

- Whole-History Rating: 0.820–0.857s, median 0.844s
- Bradley-Terry: 1.528–1.605s, median 1.575s

These figures include arena prediction before every result, result recording, all demanded fits, and the final leaderboard. WHR's defaults cap each demanded fit at 20 sweeps with a 0.1 Elo-point precision target.

## Verification

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` — 475 passed, 6 skipped
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` — passed
- `git diff --check` — passed
