### PR TITLE
Warn when dataset evaluation skips unseen competitors

### DIFF
--- a/elote/datasets/base.py
+++ b/elote/datasets/base.py
@@ -230,7 +230,9 @@ class BaseDataset(abc.ABC):
         Split the dataset into train and test sets based on competitors.
 
         This ensures that some competitors are only in the test set, which is useful for
-        evaluating how well the rating system generalizes to new competitors.
+        workflows that can evaluate new competitors. These test rows are not evaluable
+        through :func:`evaluate_arena_with_dataset` or :func:`benchmark_competitors`,
+        because those paths only score matchups between two trained competitors.
 
         Args:
             test_ratio: Ratio of competitors to reserve for testing (0.0 to 1.0)

--- a/elote/datasets/utils.py
+++ b/elote/datasets/utils.py
@@ -11,6 +11,7 @@ import numbers
 
 from elote.arenas.base import BaseArena, Bout, History
 from elote.datasets.base import DataSplit
+from elote.logging import logger
 
 
 def _scores_from_attributes(
@@ -176,6 +177,7 @@ def evaluate_arena_with_dataset(
         batch_size = len(sorted_data)
 
     total_batches = (len(sorted_data) + batch_size - 1) // batch_size
+    skipped_bouts = 0
 
     for batch_idx in range(total_batches):
         start_idx = batch_idx * batch_size
@@ -186,6 +188,7 @@ def evaluate_arena_with_dataset(
         for a, b, outcome, _, attributes in batch:
             # Skip if either competitor is not in the arena
             if a not in arena.competitors or b not in arena.competitors:
+                skipped_bouts += 1
                 continue
 
             # Get the expected outcome
@@ -200,6 +203,18 @@ def evaluate_arena_with_dataset(
         # Report progress
         if progress_callback is not None:
             progress_callback(end_idx, len(sorted_data))
+
+    if skipped_bouts > 0:
+        logger.warning(
+            "Skipped %d/%d evaluation bouts: competitor not found in training history.",
+            skipped_bouts,
+            len(sorted_data),
+        )
+    if not history.bouts:
+        logger.warning(
+            "Evaluation history is empty after evaluating %d test bouts; metrics are not meaningful.",
+            len(sorted_data),
+        )
 
     return history
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -730,10 +730,56 @@ class TestDatasetUtils(unittest.TestCase):
         arena = LambdaArena(lambda a, b, attributes=None: True)
         progress_callback = MagicMock()
 
-        history = evaluate_arena_with_dataset(arena, [], progress_callback=progress_callback)
+        with self.assertNoLogs("elote", level="WARNING"):
+            history = evaluate_arena_with_dataset(arena, [], progress_callback=progress_callback)
 
         self.assertEqual(history.bouts, [])
         progress_callback.assert_not_called()
+
+    def test_evaluate_arena_warns_once_for_skipped_unseen_competitors(self):
+        arena = LambdaArena(lambda a, b, attributes=None: True)
+        train_arena_with_dataset(arena, [("A", "B", 1.0, None, None)])
+        test_data = [
+            ("A", "B", 1.0, None, None),
+            ("A", "C", 1.0, None, None),
+            ("D", "B", 0.0, None, None),
+            ("C", "D", 0.5, None, None),
+        ]
+
+        with self.assertLogs("elote", level="WARNING") as captured:
+            history = evaluate_arena_with_dataset(arena, test_data)
+
+        self.assertEqual(len(history.bouts), 1)
+        self.assertEqual(
+            captured.output,
+            ["WARNING:elote:Skipped 3/4 evaluation bouts: competitor not found in training history."],
+        )
+
+    def test_evaluate_arena_warns_when_nonempty_test_set_yields_no_bouts(self):
+        arena = LambdaArena(lambda a, b, attributes=None: True)
+        train_arena_with_dataset(arena, [("A", "B", 1.0, None, None)])
+
+        with self.assertLogs("elote", level="WARNING") as captured:
+            history = evaluate_arena_with_dataset(arena, [("A", "C", 1.0, None, None)])
+
+        self.assertEqual(history.bouts, [])
+        self.assertEqual(
+            captured.output,
+            [
+                "WARNING:elote:Skipped 1/1 evaluation bouts: competitor not found in training history.",
+                "WARNING:elote:Evaluation history is empty after evaluating 1 test bouts; metrics are not meaningful.",
+            ],
+        )
+
+    def test_evaluate_arena_does_not_warn_when_every_row_is_evaluable(self):
+        arena = LambdaArena(lambda a, b, attributes=None: True)
+        rows = [("A", "B", 1.0, None, None)]
+        train_arena_with_dataset(arena, rows)
+
+        with self.assertNoLogs("elote", level="WARNING"):
+            history = evaluate_arena_with_dataset(arena, rows)
+
+        self.assertEqual(len(history.bouts), 1)
 
     def test_dataset_helpers_reject_non_positive_batch_sizes(self):
         arena = LambdaArena(lambda a, b, attributes=None: True)
@@ -894,6 +940,21 @@ class TestDatasetUtils(unittest.TestCase):
 
         # Check that evaluation history was recorded
         self.assertGreater(len(evaluation_history.bouts), 0)
+
+    def test_competitor_split_warns_for_every_unevaluable_test_row(self):
+        dataset = SyntheticDataset(num_competitors=30, num_matchups=600, seed=7)
+        data_split = dataset.competitor_split(test_ratio=0.2, seed=7)
+        arena = LambdaArena(lambda a, b, attributes=None: True, base_competitor=EloCompetitor)
+
+        with self.assertLogs("elote", level="WARNING") as captured:
+            _, history = train_and_evaluate_arena(arena, data_split)
+
+        skipped_message = (
+            f"WARNING:elote:Skipped {len(data_split.test)}/{len(data_split.test)} evaluation bouts: "
+            "competitor not found in training history."
+        )
+        self.assertEqual(history.bouts, [])
+        self.assertIn(skipped_message, captured.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #144

## Summary

- count dataset evaluation rows skipped because either competitor is absent from the trained population and emit one aggregate warning
- warn separately when a non-empty test set produces an empty evaluation history, while keeping empty test sets silent
- document that `competitor_split` test rows cannot be scored by the trained-population-only dataset and benchmark evaluators
- cover mixed known/unknown rows, fully empty evaluations, fully evaluable rows, and a real seeded `SyntheticDataset.competitor_split` end to end

This does not change which rows are evaluated. Scoring unseen competitors through the transient prediction path remains out of scope because it would change the semantics established for evaluation.

## Verification

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` — 473 passed, 6 skipped
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` — passed
- `git diff --check` — passed

## Mutation check

Changed the aggregate skip log from `logger.warning` to `logger.info` and ran the two skip-warning tests with `PYTHONDONTWRITEBYTECODE=1`. Both failed: the mixed fixture reported no WARNING, and the real competitor split could not find its expected `224/224` skip summary. Restoring the warning made both pass again.

The exact warning assertions guard the new logging behavior. The bout-count assertions document the unchanged selection semantics and still produce one evaluated bout for the mixed fixture and zero for the competitor split when the warning is disabled.
