### PR TITLE
Make global-fit competitor identity state-independent so they can be copied and pickled

### DIFF
--- a/elote/competitors/bradley_terry.py
+++ b/elote/competitors/bradley_terry.py
@@ -402,11 +402,9 @@ class BradleyTerryCompetitor(BaseCompetitor):
         return f"<BradleyTerryCompetitor: rating={self.rating:.3f}>"
 
     def __eq__(self, other: Any) -> bool:
-        """Check if two competitors are the same object (by unique ID)."""
-        if not isinstance(other, BradleyTerryCompetitor):
-            return NotImplemented
-        return self._id == other._id
+        """Check if two competitors are the same object."""
+        return self is other
 
     def __hash__(self) -> int:
-        """Get a hash value for this competitor based on its unique ID."""
-        return hash(self._id)
+        """Get a hash value for this competitor based on its object identity."""
+        return object.__hash__(self)

--- a/elote/competitors/colley.py
+++ b/elote/competitors/colley.py
@@ -529,7 +529,7 @@ class ColleyMatrixCompetitor(BaseCompetitor):
         return cls(initial_rating=params.get("initial_rating", cls._default_initial_rating))
 
     def __eq__(self, other: Any) -> bool:
-        """Check if two competitors are equal based on their unique ID.
+        """Check if two competitors are the same object.
 
         Args:
             other: The other competitor to compare with.
@@ -537,14 +537,12 @@ class ColleyMatrixCompetitor(BaseCompetitor):
         Returns:
             bool: True if the competitors are the same object, False otherwise.
         """
-        if not isinstance(other, ColleyMatrixCompetitor):
-            return NotImplemented
-        return self._id == other._id
+        return self is other
 
     def __hash__(self) -> int:
-        """Get a hash value for this competitor based on its unique ID.
+        """Get a hash value for this competitor based on its object identity.
 
         Returns:
             int: A hash value for this competitor.
         """
-        return hash(self._id)
+        return object.__hash__(self)

--- a/elote/competitors/keener.py
+++ b/elote/competitors/keener.py
@@ -532,11 +532,9 @@ class KeenerCompetitor(BaseCompetitor):
         return f"<KeenerCompetitor: rating={self._rating:.4f}>"
 
     def __eq__(self, other: Any) -> bool:
-        """Check if two competitors are the same object (by unique ID)."""
-        if not isinstance(other, KeenerCompetitor):
-            return NotImplemented
-        return self._id == other._id
+        """Check if two competitors are the same object."""
+        return self is other
 
     def __hash__(self) -> int:
-        """Get a hash value for this competitor based on its unique ID."""
-        return hash(self._id)
+        """Get a hash value for this competitor based on its object identity."""
+        return object.__hash__(self)

--- a/elote/competitors/massey.py
+++ b/elote/competitors/massey.py
@@ -418,11 +418,9 @@ class MasseyCompetitor(BaseCompetitor):
         return f"<MasseyCompetitor: rating={self._rating:.3f}>"
 
     def __eq__(self, other: Any) -> bool:
-        """Check if two competitors are the same object (by unique ID)."""
-        if not isinstance(other, MasseyCompetitor):
-            return NotImplemented
-        return self._id == other._id
+        """Check if two competitors are the same object."""
+        return self is other
 
     def __hash__(self) -> int:
-        """Get a hash value for this competitor based on its unique ID."""
-        return hash(self._id)
+        """Get a hash value for this competitor based on its object identity."""
+        return object.__hash__(self)

--- a/tests/test_competitor_copy.py
+++ b/tests/test_competitor_copy.py
@@ -1,0 +1,140 @@
+import copy
+import pickle
+import unittest
+
+from elote import (
+    BradleyTerryCompetitor,
+    ColleyMatrixCompetitor,
+    KeenerCompetitor,
+    LambdaArena,
+    MasseyCompetitor,
+    WholeHistoryRatingCompetitor,
+)
+
+
+# The global-fit systems are the ones that keep their opponent graph in dicts keyed by
+# competitor objects, so they are the ones whose __eq__/__hash__ pair has to stay
+# state-independent for copy and pickle to be able to rebuild a cyclic graph.
+GLOBAL_FIT_COMPETITORS = (
+    ColleyMatrixCompetitor,
+    MasseyCompetitor,
+    KeenerCompetitor,
+    BradleyTerryCompetitor,
+    WholeHistoryRatingCompetitor,
+)
+
+
+def _graph(competitor_cls):
+    """Build a three-competitor graph containing a win, another win and a tie."""
+    a, b, c = competitor_cls(), competitor_cls(), competitor_cls()
+    a.beat(b)
+    b.beat(c)
+    a.tied(c)
+    return a, b, c
+
+
+def _ratings(competitors):
+    return [competitor.rating for competitor in competitors]
+
+
+class TestGlobalFitCompetitorCopy(unittest.TestCase):
+    """Global-fit competitors must survive copy.deepcopy and pickle round trips."""
+
+    def test_deepcopy_reproduces_ratings(self):
+        for competitor_cls in GLOBAL_FIT_COMPETITORS:
+            with self.subTest(competitor=competitor_cls.__name__):
+                original = _graph(competitor_cls)
+                expected = _ratings(original)
+                copied = copy.deepcopy(original)
+                self.assertEqual(_ratings(copied), expected)
+
+    def test_pickle_reproduces_ratings(self):
+        for competitor_cls in GLOBAL_FIT_COMPETITORS:
+            with self.subTest(competitor=competitor_cls.__name__):
+                original = _graph(competitor_cls)
+                expected = _ratings(original)
+                copied = pickle.loads(pickle.dumps(original))
+                self.assertEqual(_ratings(copied), expected)
+
+    def test_copied_graph_is_independent(self):
+        """A further result on the copy moves the copy and leaves the original alone."""
+        for competitor_cls in GLOBAL_FIT_COMPETITORS:
+            for label, clone in (
+                ("deepcopy", copy.deepcopy),
+                ("pickle", lambda graph: pickle.loads(pickle.dumps(graph))),
+            ):
+                with self.subTest(competitor=competitor_cls.__name__, clone=label):
+                    original = _graph(competitor_cls)
+                    expected = _ratings(original)
+                    copied_a, copied_b, _ = clone(original)
+
+                    copied_b.beat(copied_a)
+
+                    self.assertNotEqual(copied_a.rating, expected[0])
+                    self.assertEqual(_ratings(original), expected)
+
+
+class TestGlobalFitArenaCopy(unittest.TestCase):
+    """An arena built on a global-fit competitor must be deep-copyable."""
+
+    MATCHUPS = (("a", "b"), ("b", "c"), ("c", "a"), ("a", "c"), ("b", "a"))
+
+    def _trained_arena(self, competitor_cls):
+        arena = LambdaArena(lambda a, b: a > b, base_competitor=competitor_cls)
+        for a, b in self.MATCHUPS:
+            arena.matchup(a, b)
+        return arena
+
+    def test_deepcopy_preserves_leaderboard(self):
+        for competitor_cls in GLOBAL_FIT_COMPETITORS:
+            with self.subTest(competitor=competitor_cls.__name__):
+                arena = self._trained_arena(competitor_cls)
+                expected = arena.leaderboard()
+                self.assertEqual(copy.deepcopy(arena).leaderboard(), expected)
+
+    def test_deepcopied_arena_is_independent(self):
+        for competitor_cls in GLOBAL_FIT_COMPETITORS:
+            with self.subTest(competitor=competitor_cls.__name__):
+                arena = self._trained_arena(competitor_cls)
+                expected = arena.leaderboard()
+
+                copied = copy.deepcopy(arena)
+                for _ in range(3):
+                    copied.matchup("c", "a", outcome=1.0)
+
+                self.assertNotEqual(copied.leaderboard(), expected)
+                self.assertEqual(arena.leaderboard(), expected)
+
+
+class TestGlobalFitCompetitorIdentity(unittest.TestCase):
+    """Equality and hashing stay identity-based, independent of rating state."""
+
+    def test_distinct_competitors_with_equal_ratings_are_not_equal(self):
+        for competitor_cls in GLOBAL_FIT_COMPETITORS:
+            with self.subTest(competitor=competitor_cls.__name__):
+                first, second = competitor_cls(), competitor_cls()
+                self.assertEqual(first.rating, second.rating)
+                self.assertNotEqual(first, second)
+                self.assertEqual(first, first)
+                self.assertEqual(len({first, second}), 2)
+
+    def test_hash_is_stable_across_results(self):
+        for competitor_cls in GLOBAL_FIT_COMPETITORS:
+            with self.subTest(competitor=competitor_cls.__name__):
+                a, b, _ = _graph(competitor_cls)
+                before = hash(a)
+                a.beat(b)
+                self.assertEqual(hash(a), before)
+
+    def test_copy_is_not_equal_to_its_original(self):
+        """A copy is a different object, so it must not compare equal to the original."""
+        for competitor_cls in GLOBAL_FIT_COMPETITORS:
+            with self.subTest(competitor=competitor_cls.__name__):
+                a, _, _ = _graph(competitor_cls)
+                copied = copy.deepcopy(a)
+                self.assertNotEqual(copied, a)
+                self.assertEqual(len({a, copied}), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #143

## What changed

`ColleyMatrixCompetitor`, `MasseyCompetitor`, `KeenerCompetitor` and `BradleyTerryCompetitor` keep
their opponent graph in dicts keyed by competitor objects (`_opponents`, `_head_to_head`), and the
graph is cyclic. `copy.deepcopy` and `pickle` create a bare instance and populate `__dict__`
afterwards, so the memo hands back a still-empty instance that then has to be hashed as a dict key —
and `__hash__` was `hash(self._id)`, where `_id = id(self)` is set in `__init__`. All four classes
raised a bare `AttributeError: object has no attribute '_id'` from inside their own `__hash__` on
both operations.

In all four files:

- `__hash__`: `return object.__hash__(self)` instead of `return hash(self._id)`.
- `__eq__`: `return self is other` instead of the `isinstance` guard plus `self._id == other._id`.
- The two docstrings updated to say "the same object" / "object identity" rather than "unique ID".

`_id` is untouched — it still drives the debug logging in each module and the `"id"` field in
`export_state()`.

This is the pattern `WholeHistoryRatingCompetitor` already ships (`whr.py`: `__eq__` is
`self is other`, `__hash__ = object.__hash__`), which is why WHR was already copy- and
pickle-clean at the branch point while the older four were not.

Fixing only `__hash__` would have been worse than the bug: a copied competitor inherits the
original's `_id`, so `a == a_copy` would be True while their hashes differ, breaking the hash/eq
invariant. The mutation check below covers exactly that wrong fix.

Dropping the `isinstance` guard does not change any observable comparison. Previously a
cross-type comparison returned `NotImplemented`, and Python's fallback (the other operand's
`BaseCompetitor.__eq__`, which raises and catches `MissMatchedCompetitorTypesException`, then
identity for non-competitors) resolved to `False` in every case; `self is other` returns `False`
directly.

## Tests

New `tests/test_competitor_copy.py`, 8 tests, `unittest` + `subTest` over the five global-fit
classes. The issue names four; `WholeHistoryRatingCompetitor` landed after the issue was filed,
is subject to the identical contract, and already satisfies it — including it makes the list
"every object-keyed-graph system" and guards it against regression at no cost.

- `test_deepcopy_reproduces_ratings` / `test_pickle_reproduces_ratings` — a three-competitor graph
  containing two wins and a tie, round-tripped as a tuple so the copies stay mutually linked;
  asserts all three ratings equal the originals exactly.
- `test_copied_graph_is_independent` — one further `beat()` on the copied graph moves the copy's
  rating and leaves all three original ratings byte-identical. Run for both deepcopy and pickle.
- `test_deepcopy_preserves_leaderboard` / `test_deepcopied_arena_is_independent` — a five-matchup
  `LambdaArena` on each global-fit base competitor; `copy.deepcopy(arena).leaderboard()` equals the
  original's, and further matchups on the copy leave the original's leaderboard unchanged. (Only
  deepcopy: an arena holds its comparison function, so pickling a `LambdaArena` built on a lambda
  fails for an unrelated reason.)
- `test_distinct_competitors_with_equal_ratings_are_not_equal` — `C() != C()` despite equal ratings,
  `c == c`, and `len({first, second}) == 2`.
- `test_copy_is_not_equal_to_its_original` — a deepcopy is a distinct object, so it must not compare
  equal to its original and must occupy its own slot in a set.
- `test_hash_is_stable_across_results` — hash unchanged across a result. Stated plainly: this one is
  **documentation, not a guard** — it passes on the unfixed code too, since `hash(self._id)` is also
  stable. The behaviour is carried by the other seven.

## Verification

All commands run as `env -u VIRTUAL_ENV uv run --extra dev ...` in this worktree.

**Reproduction at the branch point (`eb1967a`)** — all four classes fail both operations with
`AttributeError: '<Class>' object has no attribute '_id'`; WHR already succeeded.

**Acceptance greps** (both return no hits, exit 1):

```
grep -rn "hash(self._id)" elote/competitors/
grep -rn "self._id == other._id" elote/competitors/
```

**Suite** — `pytest -q --ignore=tests/test_examples.py`: baseline **485 passed** (measured with
`git stash -u` in this same environment), with the change **493 passed** = 485 + the 8 new tests.
Pre-existing count unchanged. Full `pytest -q tests` as CI runs it (with the `datasets` extra):
**495 passed**.

**Lint** — `ruff check .` (what `make lint` runs): `All checks passed!`. Note `ruff format --check`
already reported `colley.py` and `bradley_terry.py` as needing reformatting at `eb1967a` before this
change; that drift is pre-existing and untouched here, and `ruff format` is not a CI gate.

**Mutation checks** (`__pycache__` cleared before each run; the mutated line grepped to confirm it
landed; restored from a copy taken before mutating, not `git checkout`):

1. Reinstating `return hash(self._id)` in `elote/competitors/colley.py` → **6 of the 8 new tests
   fail**, each with `AttributeError: 'ColleyMatrixCompetitor' object has no attribute '_id'` raised
   from `colley.py:548`.
2. The plausible wrong fix — keep `object.__hash__` but restore the `_id`-based `__eq__` in
   `colley.py` → copy and pickle succeed, so tests 1 and the arena tests pass, and exactly
   **`test_copy_is_not_equal_to_its_original` fails**
   (`<ColleyMatrixCompetitor: rating=0.600, W/L/T=1/0/1> == <ColleyMatrixCompetitor: ...>`).

So the two halves of the fix are separately guarded: mutation 1 catches the `__hash__` change,
mutation 2 catches the `__eq__` change.

## Notes

- Out of scope, as the issue states: a competitor restored from serialized state keeps the
  exporting process's `_id`, and `id()` values are reusable after garbage collection. Neither
  affects behaviour now that `__eq__`/`__hash__` no longer consult `_id`.
- Noticed while writing the tests, not fixed here: `WholeHistoryRatingCompetitor`'s lazy fit is not
  bit-reproducible when a copy is fitted before its original. Deep-copying an *unfitted* WHR graph
  and reading the copy's rating first gave a value ~5e-6 away from the original's on 3 of 5 trials
  (the fit iterates over object-hash-ordered containers, so summation order depends on memory
  addresses). Materializing the rating before copying — the natural read order, and what these
  tests do — is stable across 40 trials. Pre-existing and unrelated to this change; flagging it so
  nobody writes a WHR test that copies before reading.