### PR TITLE
Identify college football competitors by program, not mascot

### DIFF
--- a/elote/datasets/football.py
+++ b/elote/datasets/football.py
@@ -12,12 +12,22 @@ from typing import List, Tuple, Dict, Any, Optional
 
 from elote.datasets.base import BaseDataset
 
+# Bumped whenever the cached CSV's schema or the meaning of its columns changes, so an
+# existing cache written by an older version of this module cannot be reused silently.
+CACHE_SCHEMA_VERSION = 2
+
 
 class CollegeFootballDataset(BaseDataset):
     """
     College football dataset for testing and evaluating different rating algorithms.
 
     This dataset contains college football games from the College Football Data API using sportsdataverse.
+
+    Competitor identifiers are the programs' display names ("Auburn Tigers", "Clemson Tigers"),
+    taken from the feed's ``home_display_name``/``away_display_name`` columns. Earlier versions
+    used ``home_name``/``away_name``, which carry only the mascot ("Tigers") and therefore merged
+    distinct programs into a single competitor. Callers that stored ratings keyed off the old
+    identifiers need to re-key or retrain them.
     """
 
     def __init__(self, cache_dir: Optional[str] = None, start_year: int = 2015, end_year: int = 2022, max_memory_mb: int = 1024):
@@ -40,8 +50,12 @@ class CollegeFootballDataset(BaseDataset):
         # Create cache directory if it doesn't exist
         os.makedirs(self.cache_dir, exist_ok=True)
 
-        # File to cache the data
-        self.data_file = os.path.join(self.cache_dir, f"college_football_games_{start_year}_{end_year}.csv")
+        # File to cache the data. The schema version is part of the name so that a cache written
+        # by an older version of this module is not reused after the column mapping changes.
+        self.data_file = os.path.join(
+            self.cache_dir,
+            f"college_football_games_v{CACHE_SCHEMA_VERSION}_{start_year}_{end_year}.csv",
+        )
 
     def download(self) -> None:
         """
@@ -102,6 +116,23 @@ class CollegeFootballDataset(BaseDataset):
         if all_games.empty:
             raise ValueError("No games data was retrieved. Check your internet connection or try again later.")
 
+        all_games = self._prepare_games(all_games)
+
+        # Save to CSV
+        all_games.to_csv(self.data_file, index=False)
+
+        print(f"Downloaded {len(all_games)} games and saved to {self.data_file}")
+
+    def _prepare_games(self, all_games: pd.DataFrame) -> pd.DataFrame:
+        """
+        Normalize a raw schedule frame into the cached CSV's schema.
+
+        Args:
+            all_games: Raw schedule rows as returned by ``sportsdataverse``.
+
+        Returns:
+            A frame with the columns this dataset caches and loads.
+        """
         # Select and rename relevant columns based on the actual column names in the data
         # First, print the columns to debug
         print(f"Available columns: {all_games.columns.tolist()}")
@@ -109,11 +140,20 @@ class CollegeFootballDataset(BaseDataset):
         # Map the columns from sportsdataverse to our expected format
         column_mapping = {
             "date": "game_date",  # Use a different name to avoid conflicts
-            "home_name": "home_team",
-            "away_name": "away_team",
             "home_score": "home_points",
             "away_score": "away_points",
         }
+
+        # The feed's home_name/away_name hold only the mascot ("Tigers"), which collapses distinct
+        # programs into one competitor. The display names ("Auburn Tigers") identify the program, so
+        # prefer them and keep the mascot columns purely as a fallback for feeds that lack them.
+        for home_src, away_src in (("home_display_name", "away_display_name"), ("home_name", "away_name")):
+            if home_src in all_games.columns and away_src in all_games.columns:
+                column_mapping[home_src] = "home_team"
+                column_mapping[away_src] = "away_team"
+                break
+        else:
+            print("Warning: no competitor identifier columns found in data")
 
         # Check which columns actually exist and create a valid mapping
         valid_mapping = {}
@@ -168,10 +208,7 @@ class CollegeFootballDataset(BaseDataset):
         if "start_date" in all_games.columns:
             all_games = all_games.sort_values(by="start_date")
 
-        # Save to CSV
-        all_games.to_csv(self.data_file, index=False)
-
-        print(f"Downloaded {len(all_games)} games and saved to {self.data_file}")
+        return all_games
 
     def load(self) -> List[Tuple[str, str, float, datetime.datetime, Dict[str, Any]]]:
         """

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -45,6 +45,10 @@ except Exception:
     HAS_FOOTBALL = False
     CollegeFootballDataset = None
 
+# The adapter class itself imports fine without sportsdataverse (that extra is only needed to
+# download), so the identifier/cache tests below run unconditionally against a local fixture.
+from elote.datasets.football import CACHE_SCHEMA_VERSION, CollegeFootballDataset as FootballDataset
+
 
 class TestDataSplit(unittest.TestCase):
     """Tests for the DataSplit class."""
@@ -666,6 +670,114 @@ class TestCollegeFootballDataset(unittest.TestCase):
             self.assertIsInstance(matchup[2], float)  # outcome
             self.assertIsInstance(matchup[3], datetime.datetime)  # timestamp
             self.assertIsInstance(matchup[4], dict)  # attributes
+
+
+class TestCollegeFootballDatasetIdentifiers(unittest.TestCase):
+    """Tests that the college football dataset names programs rather than mascots.
+
+    These build the cached CSV from a local fixture frame, so they need neither
+    sportsdataverse nor network access.
+    """
+
+    # Mirrors the ESPN feed's shape: home_name/away_name are the mascot, while
+    # home_display_name/away_display_name name the program. The second row is two
+    # different programs that share the mascot "Tigers".
+    RAW_GAMES = pd.DataFrame(
+        {
+            "date": ["2021-09-04", "2021-09-11", "2021-09-18"],
+            "start_date": ["2021-09-04", "2021-09-11", "2021-09-18"],
+            "home_name": ["Tigers", "Tigers", "Wildcats"],
+            "away_name": ["Wildcats", "Tigers", "Tigers"],
+            "home_display_name": ["Auburn Tigers", "Clemson Tigers", "Kentucky Wildcats"],
+            "away_display_name": ["Arizona Wildcats", "LSU Tigers", "Missouri Tigers"],
+            "home_score": [30, 10, 21],
+            "away_score": [10, 27, 21],
+            "status_type_completed": [True, True, True],
+        }
+    )
+
+    def setUp(self):
+        """Set up a temporary directory for testing."""
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        shutil.rmtree(self.temp_dir)
+
+    def _dataset_from(self, raw_games):
+        """Build a dataset whose cache holds the prepared form of ``raw_games``."""
+        dataset = FootballDataset(cache_dir=self.temp_dir, start_year=2021, end_year=2021)
+        dataset._prepare_games(raw_games).to_csv(dataset.data_file, index=False)
+        return dataset
+
+    def test_programs_sharing_a_mascot_stay_distinct(self):
+        """Two programs sharing a mascot must yield two distinct competitor identifiers."""
+        matchups = self._dataset_from(self.RAW_GAMES).load()
+
+        identifiers = {m[0] for m in matchups} | {m[1] for m in matchups}
+        self.assertEqual(
+            identifiers,
+            {
+                "Auburn Tigers",
+                "Arizona Wildcats",
+                "Clemson Tigers",
+                "LSU Tigers",
+                "Kentucky Wildcats",
+                "Missouri Tigers",
+            },
+        )
+
+    def test_emitted_rows_match_the_fixture(self):
+        """Each row names its two programs and carries the outcome implied by the scores."""
+        matchups = self._dataset_from(self.RAW_GAMES).load()
+
+        self.assertEqual(
+            [(a, b, outcome) for a, b, outcome, _timestamp, _attributes in matchups],
+            [
+                ("Auburn Tigers", "Arizona Wildcats", 1.0),
+                ("Clemson Tigers", "LSU Tigers", 0.0),
+                ("Kentucky Wildcats", "Missouri Tigers", 0.5),
+            ],
+        )
+
+    def test_no_row_pairs_a_competitor_with_itself(self):
+        """A competitor must never appear on both sides of the same row."""
+        matchups = self._dataset_from(self.RAW_GAMES).load()
+
+        for competitor_a, competitor_b, _outcome, _timestamp, _attributes in matchups:
+            self.assertNotEqual(competitor_a, competitor_b)
+
+    def test_falls_back_to_name_columns_when_display_names_missing(self):
+        """A feed without the display-name columns still yields identifiers."""
+        raw_games = self.RAW_GAMES.drop(columns=["home_display_name", "away_display_name"])
+        matchups = self._dataset_from(raw_games).load()
+
+        identifiers = {m[0] for m in matchups} | {m[1] for m in matchups}
+        self.assertEqual(identifiers, {"Tigers", "Wildcats"})
+
+    def test_cache_path_carries_the_schema_version(self):
+        """The cached CSV path is versioned, so a stale cache cannot suppress the mapping."""
+        dataset = FootballDataset(cache_dir=self.temp_dir, start_year=2020, end_year=2021)
+
+        self.assertEqual(
+            os.path.basename(dataset.data_file),
+            f"college_football_games_v{CACHE_SCHEMA_VERSION}_2020_2021.csv",
+        )
+
+        # A cache written by the pre-fix code lives at the unversioned path and is ignored.
+        legacy_path = os.path.join(self.temp_dir, "college_football_games_2020_2021.csv")
+        pd.DataFrame(
+            {
+                "start_date": ["2020-09-05"],
+                "home_team": ["Tigers"],
+                "away_team": ["Tigers"],
+                "home_points": [28],
+                "away_points": [21],
+            }
+        ).to_csv(legacy_path, index=False)
+
+        self.assertNotEqual(dataset.data_file, legacy_path)
+        self.assertFalse(os.path.exists(dataset.data_file))
 
 
 class TestDatasetUtils(unittest.TestCase):


### PR DESCRIPTION
Closes #129

`CollegeFootballDataset.download()` mapped ESPN's `home_name`/`away_name` into the
`home_team`/`away_team` columns that `load()` emits as caller identifiers. Those columns
carry only the **mascot** ("Tigers"), not the program — so distinct programs collapsed into
a single rated competitor, and a row could pair a competitor with itself (Auburn vs. LSU
became `Tigers` vs. `Tigers`).

## What changed

`elote/datasets/football.py`:

- The identifier mapping now prefers `home_display_name`/`away_display_name` ("Auburn Tigers"),
  which name the program. `home_name`/`away_name` remain as a **fallback**, selected only when
  the display-name columns are absent from the feed — this reuses the function's existing
  "which columns actually exist" shape.
- The cached CSV path is now versioned: `college_football_games_v{CACHE_SCHEMA_VERSION}_{start}_{end}.csv`.
  `download()` returns early whenever `self.data_file` exists, so without this a cache written by
  the previous code would keep serving mascot identifiers and the fix would be invisible.
  The new module constant `CACHE_SCHEMA_VERSION = 2` is what the filename and the test both read.
- The post-fetch column normalization moved from the body of `download()` into a
  `_prepare_games(all_games)` helper (pure frame in, frame out). This is what makes the mapping
  testable from a local DataFrame with neither `sportsdataverse` nor network access; `download()`
  calls it, so the tests exercise the real code path. No behaviour changed in the move.
- The class docstring records the identifier change — callers who stored ratings keyed off the
  old mascot strings need to re-key or retrain.

`tests/test_datasets.py`: new `TestCollegeFootballDatasetIdentifiers`, built from a local fixture
frame and **not** skip-marked — `CollegeFootballDataset` imports fine without the optional extra
(only `download()`'s network path needs it), so the `HAS_FOOTBALL` guard would have been wrong here.
The fixture mirrors the feed's shape (both mascot and display-name columns present) and includes
two different programs sharing the mascot "Tigers".

Out of scope, noted only: the dataset puts `home_score`/`away_score` in `attributes` but no helper
forwards them to the `scores=` channel.

## Verification

All commands run from the branch worktree.

**Suite and lint (as the issue specifies):**

```
$ env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py
484 passed, 6 skipped, 2 warnings in 6.34s     # 479 passed / 6 skipped on master, +5 new

$ env -u VIRTUAL_ENV uv run --extra dev ruff check .
All checks passed!
```

Also ran the full `pytest -q tests` that CI's tox env invokes: **486 passed, 6 skipped**.
(That regenerates `images/colley_matrix_ratings.png`; reverted, and `git status` is clean.)

**The pre-existing football tests are skipped locally without `sportsdataverse`, but CI installs
`[dev,datasets]` and runs them.** To confirm they still pass under the new mapping I put a stub
`sportsdataverse.cfb` module on `PYTHONPATH` so `HAS_FOOTBALL` becomes true and the existing
`@patch("sportsdataverse.cfb.espn_cfb_schedule")` tests actually execute:

```
$ env -u VIRTUAL_ENV PYTHONPATH="$STUB" uv run --extra dev pytest -q tests/test_datasets.py -k "Football or football"
8 passed, 38 deselected
```

Their mock frames carry only `home_name`/`away_name`, so this also exercises the fallback branch
end-to-end through `download()`, not just through the helper.

**Mutation checks** (fix committed first, then mutated, `__pycache__` cleared each time, and the
restore verified by reading the value the interpreter actually imports):

1. *Mapping reverted to `home_name`/`away_name`* — the selection tuple changed to
   `(("home_name", "away_name"),)`:
   **3 failed, 2 passed.** `test_programs_sharing_a_mascot_stay_distinct` (got `{Tigers, Wildcats}`,
   expected the six programs), `test_emitted_rows_match_the_fixture`, and
   `test_no_row_pairs_a_competitor_with_itself` all fail — i.e. the tests do fail with the column
   mapping reverted, as the issue asked me to confirm.

2. *Cache path reverted* to the unversioned `college_football_games_{start}_{end}.csv`:
   **1 failed** — `test_cache_path_carries_the_schema_version`.

Which test carries which guarantee, plainly:

- The three tests in mutation 1 carry the identifier behaviour.
- `test_cache_path_carries_the_schema_version` carries the cache invalidation, and separately
  asserts that a legacy-named CSV sitting in the cache dir is *not* the path the dataset reads.
- `test_falls_back_to_name_columns_when_display_names_missing` passes on **both** the fixed and the
  reverted code — it documents that the fallback still works, it does not guard the fix. The
  stub-module run above is what proves the fallback survives the whole `download()` path.

After restoring, the suite is back to 484 passed / 6 skipped and `git diff master --stat` shows only
`elote/datasets/football.py` and `tests/test_datasets.py`.