### PR TITLE
Normalize Massey's expected_score by the fitted rating scale

### DIFF
--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -126,7 +126,7 @@ Mathematical Formulation
    * - **Colley Matrix**
      - Ratings solve :math:`C r = b`; :math:`E_A = \frac{1}{1 + e^{-4 (r_A - r_B)}}`
    * - **Massey**
-     - Ratings solve :math:`M r = p` with :math:`M = D - A`; :math:`E_A = \frac{1}{1 + e^{-2 (r_A - r_B)}}`
+     - Ratings solve :math:`M r = p` with :math:`M = D - A`; :math:`E_A = \frac{1}{1 + e^{-2 (r_A - r_B) / \sigma}}`, where :math:`\sigma` is the fitted rating spread
    * - **Keener**
      - Ratings are the dominant eigenvector of :math:`H_{ij} = h(a_{ij}) / g_i + \varepsilon` with :math:`a_{ij} = \frac{S_{ij} + 1}{S_{ij} + S_{ji} + 2}` and :math:`h(x) = \frac{1}{2} + \frac{1}{2}\mathrm{sgn}(x - \frac{1}{2})\sqrt{|2x - 1|}`; :math:`E_A = \frac{r_A}{r_A + r_B}`
    * - **Pythagorean**

--- a/docs/source/rating_systems/massey.rst
+++ b/docs/source/rating_systems/massey.rst
@@ -44,9 +44,31 @@ competitors is a logistic function of their rating difference:
 
 .. math::
 
-   E_a = \frac{1}{1 + e^{-s\,(r_a - r_b)}}
+   E_a = \frac{1}{1 + e^{-s\,(r_a - r_b) / \sigma}}
 
-with a class-configurable scale :math:`s` (default 2.0).
+with a class-configurable sharpness :math:`s` (default 2.0).
+
+Normalized rating difference
+----------------------------
+
+The divisor :math:`\sigma` is the **fitted rating scale**: the root-mean-square rating difference
+between two members of the connected group, recorded on every competitor alongside the fit. For a
+zero-mean group that is :math:`\sqrt{2}` times the population standard deviation of the ratings.
+
+This matters because a Massey rating carries the caller's own units. With unit margins the ratings
+sit within roughly :math:`\pm 1`, but with real point scores they are **points per game**, so
+:math:`r_a - r_b` is routinely 10-30 rather than 0.1-1. Dividing by :math:`\sigma` makes the
+logistic argument dimensionless, so:
+
+- probabilities do not saturate to exactly ``0.0`` / ``1.0`` once real point margins are supplied
+  (which would make log loss unbounded and flatten the calibration curve);
+- the same schedule expressed in different point units gives the same probabilities;
+- :math:`s` stays a pure sharpness knob rather than a unit-dependent constant.
+
+The normalization is monotone, so it changes no ordering, no rating and no leaderboard -- only the
+probabilities ``expected_score`` reports. The scale is ``1.0`` for a competitor that has never been
+fitted, so a directly constructed competitor divides by one, and it is carried through
+``export_state()`` / ``from_state()`` as ``rating_scale``.
 
 Margins
 -------
@@ -139,8 +161,17 @@ Customization
 Key parameters:
 
 - **initial_rating**: starting rating value (default: 0.0).
-- **expected_score_scale**: class-level logistic scale used by ``expected_score`` (default: 2.0),
-  settable with ``MasseyCompetitor.configure_class(expected_score_scale=...)``.
+- **expected_score_scale**: class-level sharpness multiplier used by ``expected_score``
+  (default: 2.0), settable with ``MasseyCompetitor.configure_class(expected_score_scale=...)``. It
+  multiplies the *normalized* rating difference, so it does not depend on the units of the scores
+  fed in.
+
+State recorded alongside the fit:
+
+- **rating_scale**: the fitted rating spread ``expected_score`` divides by (see
+  `Normalized rating difference`_). It is ``1.0`` until the competitor is first fitted, is
+  recomputed for the whole connected group on every result, and round-trips through
+  ``export_state()``.
 
 Real-World Applications
 ---------------------

--- a/elote/competitors/massey.py
+++ b/elote/competitors/massey.py
@@ -58,12 +58,21 @@ class MasseyCompetitor(BaseCompetitor):
     - Ratings are zero mean within a connected group, so roughly half of them are negative
     - The rating difference is directly interpretable as a predicted margin
 
+    **Rating scale.** Because the rating difference carries the caller's own units, every fit
+    also records ``_rating_scale``, the spread of the connected group's ratings.
+    :meth:`expected_score` divides by it, so the win probabilities do not change when the same
+    schedule is expressed in different point units, and do not saturate to 0.0/1.0 when real
+    point margins put the ratings on a points-per-game scale. It is ``1.0`` for a competitor
+    that has never been fitted, and it survives :meth:`export_state` / :meth:`from_state`.
+
     Class Attributes:
         _minimum_rating (float): The minimum allowed rating value. Default: ``-inf``. Massey
             ratings are zero mean and routinely negative, so no floor is imposed.
         _default_initial_rating (float): Default initial rating. Default: 0.0.
-        _expected_score_scale (float): Logistic scale used by :meth:`expected_score` to turn a
-            rating difference into a win probability. Default: 2.0, chosen so that the widest
+        _expected_score_scale (float): Dimensionless sharpness multiplier used by
+            :meth:`expected_score`. The rating difference is divided by the fitted rating
+            spread before it reaches the logistic, so this constant does not depend on the
+            units the caller's scores are in. Default: 2.0, chosen so that the widest
             plausible unit-margin gap maps to roughly the same probability as the widest gap
             under Colley's ``1 / (1 + exp(-4 * diff))``.
         _round_decimals (int): Number of decimal places fitted ratings are canonicalized to, so
@@ -74,6 +83,8 @@ class MasseyCompetitor(BaseCompetitor):
     _default_initial_rating: ClassVar[float] = 0.0
     _expected_score_scale: ClassVar[float] = 2.0
     _round_decimals: ClassVar[int] = 13
+    # Floor for the fitted rating spread, so a degenerate all-equal group cannot divide by zero.
+    _minimum_rating_scale: ClassVar[float] = 1e-9
 
     def __init__(self, initial_rating: Optional[float] = None):
         """Initialize a new Massey competitor.
@@ -92,6 +103,10 @@ class MasseyCompetitor(BaseCompetitor):
         # margins this is simply wins minus losses; with real scores it is the sum of
         # ``self_score - opponent_score`` over every game played.
         self._point_differential = 0.0
+        # Spread of the connected group's fitted ratings, used to make the argument of the
+        # expected-score logistic dimensionless. 1.0 until this competitor is fitted, so a
+        # directly constructed competitor keeps the raw rating difference.
+        self._rating_scale = 1.0
         self._opponents: Dict["MasseyCompetitor", int] = {}  # Opponent -> num games
         self._margins_for: Dict["MasseyCompetitor", float] = {}
         # Unique ID for hashing (instances are used as dict keys in the match graph).
@@ -138,7 +153,12 @@ class MasseyCompetitor(BaseCompetitor):
 
         Massey ratings are on a margin scale rather than a probability scale, so the predicted
         margin ``r_self - r_competitor`` is squashed through a logistic function to obtain a
-        win probability. Two competitors with equal ratings give exactly 0.5, and the two
+        win probability. Because that margin is in whatever units the caller's scores are in --
+        unit margins when ``scores`` is omitted, points per game when it is supplied -- the
+        difference is first divided by the fitted rating spread (the root-mean-square rating
+        difference within the connected group, see :meth:`_update_rating_scale`). That makes
+        the logistic argument dimensionless and leaves ``_expected_score_scale`` a pure
+        sharpness knob. Two competitors with equal ratings give exactly 0.5, and the two
         argument orders are exactly complementary.
 
         Args:
@@ -151,10 +171,14 @@ class MasseyCompetitor(BaseCompetitor):
             MissMatchedCompetitorTypesException: If the competitor types don't match.
         """
         self.verify_competitor_types(competitor)
-        rating_diff = self.rating - competitor.rating
+        opponent = cast(MasseyCompetitor, competitor)
+        rating_diff = self.rating - opponent.rating
+        # Symmetric in the two competitors, so the exact complementarity of the tanh form below
+        # is preserved: both argument orders divide by the same number.
+        scale = max(self._rating_scale, opponent._rating_scale)
         # tanh form: symmetric in the sign of rating_diff, so the two argument orders sum to
         # exactly 1.0 in floating point.
-        return float(0.5 * (1.0 + np.tanh(0.5 * self._expected_score_scale * rating_diff)))
+        return float(0.5 * (1.0 + np.tanh(0.5 * self._expected_score_scale * (rating_diff / scale))))
 
     def beat(self, competitor: BaseCompetitor, *, scores: Optional[Sequence[float]] = None) -> None:
         """Update ratings after this competitor has won against the given competitor.
@@ -266,7 +290,9 @@ class MasseyCompetitor(BaseCompetitor):
 
         Builds ``M = D - A`` and the cumulative-margin vector ``p``, replaces the last row of
         ``M`` with all ones (and the last entry of ``p`` with zero) to remove the singularity,
-        and solves the resulting system. The constraint pins the ratings to zero mean.
+        and solves the resulting system. The constraint pins the ratings to zero mean. The
+        spread of the fitted ratings is recorded on every member of the group so that
+        :meth:`expected_score` can normalize by it.
         """
         competitors = self._get_connected_competitors()
         n = len(competitors)
@@ -301,6 +327,7 @@ class MasseyCompetitor(BaseCompetitor):
                 n,
             )
             self._fallback_rating_calculation(competitors)
+            self._update_rating_scale(competitors)
             return
 
         # The solver's pivoting depends on the row order, which is the order competitors were
@@ -311,6 +338,28 @@ class MasseyCompetitor(BaseCompetitor):
 
         for i, comp in enumerate(competitors):
             comp.rating = float(r[i])
+
+        self._update_rating_scale(competitors)
+
+    @classmethod
+    def _update_rating_scale(cls, competitors: List["MasseyCompetitor"]) -> None:
+        """Record the fitted group's rating spread on every member of the group.
+
+        The spread is the root-mean-square rating difference between two members of the group
+        -- the natural scale for the *difference* :meth:`expected_score` normalizes. For a
+        zero-mean group that is exactly ``sqrt(2)`` times the population standard deviation of
+        the ratings. It is canonicalized to ``_round_decimals`` places like the ratings
+        themselves, so that the group's discovery order cannot change it in the last bits, and
+        floored at ``_minimum_rating_scale`` so a degenerate all-equal group cannot divide by
+        zero.
+
+        Args:
+            competitors: The connected group that was just fitted.
+        """
+        spread = np.sqrt(2.0) * np.std([comp.rating for comp in competitors])
+        scale = max(float(np.round(spread, decimals=cls._round_decimals)), cls._minimum_rating_scale)
+        for comp in competitors:
+            comp._rating_scale = scale
 
     def _fallback_rating_calculation(self, competitors: List["MasseyCompetitor"]) -> None:
         """Assign average-margin ratings when the linear system cannot be solved.
@@ -345,6 +394,7 @@ class MasseyCompetitor(BaseCompetitor):
             "losses": self._losses,
             "ties": self._ties,
             "point_differential": self._point_differential,
+            "rating_scale": self._rating_scale,
         }
 
     def _import_parameters(self, parameters: Dict[str, Any]) -> None:
@@ -370,6 +420,7 @@ class MasseyCompetitor(BaseCompetitor):
         self._losses = state.get("losses", 0)
         self._ties = state.get("ties", 0)
         self._point_differential = state.get("point_differential", float(self._wins - self._losses))
+        self._rating_scale = state.get("rating_scale", 1.0)
         self._opponents = {}
         self._margins_for = {}
 
@@ -393,6 +444,7 @@ class MasseyCompetitor(BaseCompetitor):
         self._losses = 0
         self._ties = 0
         self._point_differential = 0.0
+        self._rating_scale = 1.0
         self._opponents = {}
         self._margins_for = {}
 

--- a/tests/test_MasseyCompetitor.py
+++ b/tests/test_MasseyCompetitor.py
@@ -1,4 +1,6 @@
 import json
+import math
+import random
 import unittest
 
 from elote import EloCompetitor, LambdaArena, MasseyCompetitor
@@ -294,3 +296,136 @@ class TestMasseyRatingSetterValidation(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def _football_shaped_schedule(seed=17, competitors=20, matchups=300):
+    """Build a seeded schedule of point-scored games on a points-per-game scale.
+
+    Each competitor gets a latent strength drawn from ``N(0, 10)``; a game between ``a`` and
+    ``b`` scores each side from ``N(28 +/- (s_a - s_b) / 2, 10)``, rounded and floored at zero,
+    so margins are tens of points rather than the unit margins Massey falls back to when no
+    ``scores`` payload is supplied.
+
+    Returns:
+        list: ``(a, b, a_score, b_score)`` tuples, all decisive.
+    """
+    rng = random.Random(seed)
+    names = ["c%d" % i for i in range(competitors)]
+    strength = {name: rng.gauss(0, 10) for name in names}
+
+    schedule = []
+    for _ in range(matchups):
+        a, b = rng.sample(names, 2)
+        edge = strength[a] - strength[b]
+        a_score = max(0, round(rng.gauss(28 + edge / 2, 10)))
+        b_score = max(0, round(rng.gauss(28 - edge / 2, 10)))
+        if a_score == b_score:
+            a_score += 1
+        schedule.append((a, b, float(a_score), float(b_score)))
+    return schedule
+
+
+def _trained_arena_predictions(train_fraction=0.7, **kwargs):
+    """Train a score-fed Massey arena on part of a schedule and predict the rest.
+
+    Returns:
+        list: ``(predicted_probability_for_a, actual_outcome)`` pairs for the held-out games.
+    """
+    schedule = _football_shaped_schedule(**kwargs)
+    split = int(len(schedule) * train_fraction)
+
+    arena = LambdaArena(None, base_competitor=MasseyCompetitor)
+    for a, b, a_score, b_score in schedule[:split]:
+        arena.matchup(a, b, outcome=1.0 if a_score > b_score else 0.0, scores=(a_score, b_score))
+
+    return [
+        (arena.expected_score(a, b), 1.0 if a_score > b_score else 0.0) for a, b, a_score, b_score in schedule[split:]
+    ]
+
+
+class TestMasseyScoredArenaProbabilities(unittest.TestCase):
+    """Predicted probabilities stay usable once Massey is fed real point margins.
+
+    With real scores the fitted ratings are points per game, so the rating difference is
+    routinely tens of points. Without the rating-scale normalization in ``expected_score`` the
+    logistic saturates and returns exactly 0.0 / 1.0, which makes log loss unbounded. These
+    tests assert on probability values, not on accuracy -- accuracy is structurally blind to
+    the defect, since the normalization is a monotone recalibration that reorders nothing.
+    """
+
+    def setUp(self):
+        self.predictions = _trained_arena_predictions()
+        self.probabilities = [p for p, _ in self.predictions]
+
+    def test_no_prediction_is_degenerate(self):
+        """No held-out prediction is exactly 0.0 or 1.0."""
+        self.assertEqual([p for p in self.probabilities if p in (0.0, 1.0)], [])
+
+    def test_no_prediction_lands_in_the_extreme_bins(self):
+        """No held-out prediction is <= 1e-3 or >= 1 - 1e-3."""
+        extreme = [p for p in self.probabilities if p <= 1e-3 or p >= 1 - 1e-3]
+        self.assertEqual(extreme, [], "%d of %d predictions saturated" % (len(extreme), len(self.probabilities)))
+        self.assertGreater(min(self.probabilities), 0.008)
+        self.assertLess(max(self.probabilities), 0.992)
+
+    def test_log_loss_and_brier_are_pinned(self):
+        """Value assertions on this arena's calibration, so a future remapping is visible."""
+        n = len(self.predictions)
+        self.assertEqual(n, 90)
+
+        log_loss = sum(-(y * math.log(p) + (1 - y) * math.log(1 - p)) for p, y in self.predictions) / n
+        brier = sum((p - y) ** 2 for p, y in self.predictions) / n
+
+        self.assertAlmostEqual(log_loss, 0.4938, places=4)
+        self.assertAlmostEqual(brier, 0.1610, places=4)
+
+    def test_accuracy_is_unchanged_by_the_normalization(self):
+        """Documentation, not a guard: accuracy cannot see the defect at all."""
+        correct = sum(1 for p, y in self.predictions if (p > 0.5) == (y > 0.5))
+        self.assertAlmostEqual(correct / len(self.predictions), 0.7555555555555555, places=12)
+
+
+class TestMasseyRatingScale(unittest.TestCase):
+    """The fitted rating scale that makes the expected-score logistic dimensionless."""
+
+    def test_defaults_to_one_for_an_unfitted_competitor(self):
+        self.assertEqual(MasseyCompetitor()._rating_scale, 1.0)
+        self.assertEqual(MasseyCompetitor(initial_rating=7.5)._rating_scale, 1.0)
+
+    def test_expected_score_is_invariant_to_the_unit_of_the_scores(self):
+        """The same schedule in tenths of a point gives the same probabilities."""
+        points = [("a", "b", 31.0, 17.0), ("b", "c", 24.0, 20.0), ("a", "c", 45.0, 10.0)]
+
+        def fit(factor):
+            competitors = {name: MasseyCompetitor() for name in "abc"}
+            for first, second, first_score, second_score in points:
+                competitors[first].beat(competitors[second], scores=(first_score * factor, second_score * factor))
+            return competitors
+
+        unit, scaled = fit(1.0), fit(10.0)
+        for first, second in (("a", "b"), ("b", "c"), ("a", "c")):
+            with self.subTest(pair=(first, second)):
+                self.assertAlmostEqual(
+                    unit[first].expected_score(unit[second]),
+                    scaled[first].expected_score(scaled[second]),
+                    places=12,
+                )
+
+    def test_scale_survives_the_state_round_trip(self):
+        a, b, c = MasseyCompetitor(), MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b, scores=(31.0, 17.0))
+        b.beat(c, scores=(24.0, 20.0))
+
+        self.assertGreater(a._rating_scale, 1.0)
+
+        restored = MasseyCompetitor.from_state(json.loads(json.dumps(a.export_state())))
+        self.assertEqual(restored._rating_scale, a._rating_scale)
+        self.assertEqual(restored.expected_score(c), a.expected_score(c))
+
+    def test_reset_restores_the_unfitted_scale(self):
+        a, b = MasseyCompetitor(), MasseyCompetitor()
+        a.beat(b, scores=(31.0, 17.0))
+        self.assertNotEqual(a._rating_scale, 1.0)
+
+        a.reset()
+        self.assertEqual(a._rating_scale, 1.0)


### PR DESCRIPTION
Closes #128

## What changed

`MasseyCompetitor.expected_score` fed the raw rating difference into
`0.5 * (1 + tanh(0.5 * _expected_score_scale * diff))`. That constant is only sane while
ratings are on the unit-margin scale; once real point margins are supplied the ratings are
**points per game**, `diff` is routinely 10-30, and the `tanh` saturates to exactly `0.0` /
`1.0` — which makes log loss unbounded and flattens the calibration curve.

- Every fit now records a `_rating_scale` on each member of the connected group, and
  `expected_score` divides the rating difference by `max(self._rating_scale,
  competitor._rating_scale)` before the logistic. The `max` is symmetric, so the exactly
  complementary `tanh` form is preserved.
- `_rating_scale` defaults to `1.0` for a never-fitted competitor, is reset by `reset()`, and
  round-trips through `export_state()` / `from_state()` as `rating_scale`.
- `_expected_score_scale` is unchanged at 2.0 and is now a purely dimensionless sharpness knob.
- Docs: a new "Normalized rating difference" section plus a `rating_scale` entry in the
  key-parameters list of `docs/source/rating_systems/massey.rst`, and the (now stale) Massey
  formula row in `comparison.rst`.

Ratings, the linear solve, orderings and leaderboards are untouched — the normalization is a
monotone recalibration, so accuracy is identical (see the table below).

### One deviation from the issue's sketch, with the measurement behind it

The issue suggested "e.g. the population standard deviation of the fitted ratings". I used the
**root-mean-square rating difference within the group** instead, which for a zero-mean group is
exactly `sqrt(2)` times that standard deviation. Rationale: the quantity being normalized is a
*difference*, so the natural scale is the spread of differences, not the spread of ratings.

It also turns out to be what makes the acceptance criterion reachable rather than seed luck.
Over 50 seeds of the football-shaped harness (20 competitors, 300 matchups, 70/30):

| divisor | seeds with any p <= 1e-3 or >= 1-1e-3 | worst min | worst max | median log loss |
|---|---|---|---|---|
| population std (`sigma`) | **31 / 50** | 0.00010 | 0.99991 | 0.5666 |
| RMS pairwise difference (`sqrt(2)*sigma`) | **0 / 50** | 0.00151 | 0.99864 | 0.5224 |

With the plain standard deviation, half of all fixtures still put an extreme pair in the end
bins (for a normal sample of 20, the top-to-bottom gap is ~3.7 sd, and `0.5*(1+tanh(3.7))` is
0.99935). The `sqrt(2)` divisor is not fixture tuning — it removes the failure mode across every
seed tried, and improves median log loss as well.

No acceptance literal had to move: `test_expected_score` (0.7310585786300049 / 0.2689414213699951)
and `TestMasseyExpectedScore::test_scale_is_class_configurable` pass **unmodified**, because both
use directly constructed competitors whose scale is 1.0.

## Verification

All commands run from the repo root.

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q --ignore=tests/test_examples.py` -> **500 passed,
  6 skipped** (base `master` measured with `git stash -u` in the same env: 492 passed, 6 skipped;
  +8 new tests, no existing test modified).
- `env -u VIRTUAL_ENV uv run --extra dev pytest -q tests` (what CI runs) -> **502 passed, 6 skipped**.
  This regenerates tracked PNGs under `images/`; those were reverted and are not in the diff.
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` -> All checks passed.
- `env -u VIRTUAL_ENV uv run --extra dev mypy elote` -> Success: no issues found in 28 source files.
- Docs build (`sphinx-build -b html source build/html` with `docs/requirements.txt`) -> build
  succeeded, **531 warnings on both base and branch** — no new warnings.

### Before / after on the new fixture

`TestMasseyScoredArenaProbabilities` trains a seeded 20-competitor / 300-matchup arena on
football-shaped scores (latent strength `N(0, 10)`, points `N(28 +/- edge/2, 10)`), 70/30 split,
and predicts the 90 held-out games:

| | min p | max p | p <= 1e-3 or >= 1-1e-3 | p exactly 0.0/1.0 | Brier | log loss | accuracy |
|---|---|---|---|---|---|---|---|
| before (normalization reverted) | 0.000000 | 1.000000 | **80 / 90** | **26 / 90** | 0.2293 | 3.6362* | 0.7556 |
| after | 0.008946 | 0.991201 | **0 / 90** | **0 / 90** | 0.1610 | 0.4938 | 0.7556 |

\* the "before" log loss is only finite because the measurement clipped at 1e-15; the code's own
output makes it unbounded. Accuracy is byte-identical, confirming the change reorders nothing —
which is why the new tests assert on probability values, Brier and log loss, never on accuracy.

### Mutation testing (the tests are not vacuous)

Each mutation applied to `elote/competitors/massey.py`, suite re-run, then restored (`__pycache__`
suppressed via `PYTHONDONTWRITEBYTECODE=1`, and the mutated line re-read back out of the imported
module to confirm it was live):

1. **Original bug** — `scale = max(...)` -> `scale = 1.0`: **4 tests fail**
   (`test_no_prediction_is_degenerate`, `test_no_prediction_lands_in_the_extreme_bins` reporting
   "80 of 90 predictions saturated", `test_log_loss_and_brier_are_pinned`,
   `test_expected_score_is_invariant_to_the_unit_of_the_scores`).
2. **Plausible wrong fix** — no normalization, but clamp the returned probability to
   `[2e-3, 1-2e-3]`: **2 tests fail**. Clamping kills the exactly-0.0/1.0 symptom and the naive
   extreme-bin check, so it is caught only by the min/max headroom assertions and by the pinned
   log loss / Brier. That is what those two assertions are for.
3. **Wrong divisor** — `sqrt(2)*std` -> plain `std`: **2 tests fail** (the pinned literals and the
   min-headroom assertion), so the value assertion does pin the mapping as the issue asked.

`test_accuracy_is_unchanged_by_the_normalization` passes under every mutation above — it is
documentation of the monotonicity claim, not a guard, and is labelled as such in its docstring.
The behaviour is carried by the four tests in mutation 1.