### PR TITLE
Never cache a college football download that lost a season

### DIFF
--- a/elote/datasets/football.py
+++ b/elote/datasets/football.py
@@ -11,6 +11,7 @@ import pandas as pd
 from typing import List, Tuple, Dict, Any, Optional
 
 from elote.datasets.base import BaseDataset
+from elote.logging import logger
 
 # Bumped whenever the cached CSV's schema or the meaning of its columns changes, so an
 # existing cache written by an older version of this module cannot be reused silently.
@@ -91,6 +92,9 @@ class CollegeFootballDataset(BaseDataset):
         all_games = pd.DataFrame()
 
         # Download data for each year
+        failed_years: Dict[int, str] = {}
+        empty_years: List[int] = []
+
         for year in range(self.start_year, self.end_year + 1):
             print(f"Fetching data for {year}...")
             try:
@@ -104,17 +108,40 @@ class CollegeFootballDataset(BaseDataset):
                     return_as_pandas=True,
                 )
 
-                if year_data is not None and not year_data.empty:
-                    # Keep only completed games
-                    year_data = year_data[year_data["status_type_completed"] == True]  # noqa: E712
-                    all_games = pd.concat([all_games, year_data], ignore_index=True)
-            except Exception as e:
-                print(f"Error fetching data for year {year}: {e}")
-                print("Continuing with next year...")
-                continue
+                if year_data is None or year_data.empty:
+                    empty_years.append(year)
+                    logger.warning("Season %d returned no games from the upstream feed.", year)
+                    continue
+
+                # Keep only completed games
+                year_data = year_data[year_data["status_type_completed"] == True]  # noqa: E712
+                all_games = pd.concat([all_games, year_data], ignore_index=True)
+            except Exception as e:  # noqa: BLE001 - reported below, never swallowed
+                failed_years[year] = f"{type(e).__name__}: {e}"
+                logger.warning("Fetching season %d failed: %s", year, failed_years[year])
+
+        if failed_years:
+            # A partial download must never be cached. The cache is keyed only by the
+            # requested year range, so writing a short result here would make every later
+            # run silently read a dataset with a season missing, with nothing to signal it.
+            detail = "; ".join(f"{year} ({reason})" for year, reason in sorted(failed_years.items()))
+            raise RuntimeError(
+                f"Failed to fetch {len(failed_years)} of "
+                f"{self.end_year - self.start_year + 1} requested seasons: {detail}. "
+                "Nothing was cached; re-run to retry."
+            )
 
         if all_games.empty:
             raise ValueError("No games data was retrieved. Check your internet connection or try again later.")
+
+        if empty_years:
+            logger.warning(
+                "Seasons with no games in the feed: %s. The cached dataset covers %d-%d "
+                "but does not contain these seasons.",
+                ", ".join(str(year) for year in empty_years),
+                self.start_year,
+                self.end_year,
+            )
 
         all_games = self._prepare_games(all_games)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1069,5 +1069,69 @@ class TestDatasetUtils(unittest.TestCase):
         self.assertIn(skipped_message, captured.output)
 
 
+
+class TestCollegeFootballPartialDownload(unittest.TestCase):
+    """A season that fails to fetch must not be silently cached.
+
+    The cache file is keyed only by the requested year range, so writing a short result
+    after a transient failure makes every later run read a dataset with a season missing
+    and nothing to signal it.
+    """
+
+    def setUp(self):
+        self.cache_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.cache_dir, True)
+
+    @staticmethod
+    def _season_frame(year, rows=3):
+        return pd.DataFrame(
+            {
+                "start_date": [f"{year}-09-0{i + 1}T17:00Z" for i in range(rows)],
+                "home_display_name": [f"Home {year} {i}" for i in range(rows)],
+                "away_display_name": [f"Away {year} {i}" for i in range(rows)],
+                "home_score": [20 + i for i in range(rows)],
+                "away_score": [10 + i for i in range(rows)],
+                "neutral_site": [False] * rows,
+                "status_type_completed": [True] * rows,
+            }
+        )
+
+    def _run_download(self, schedule_side_effect):
+        from elote.datasets.football import CollegeFootballDataset
+
+        dataset = CollegeFootballDataset(cache_dir=self.cache_dir, start_year=2019, end_year=2021)
+        fake_cfb = MagicMock()
+        fake_cfb.espn_cfb_schedule.side_effect = schedule_side_effect
+        fake_pkg = MagicMock()
+        fake_pkg.cfb = fake_cfb
+        # `import sportsdataverse.cfb as cfb` resolves the submodule from sys.modules.
+        with patch.dict(
+            "sys.modules",
+            {"sportsdataverse": fake_pkg, "sportsdataverse.cfb": fake_cfb},
+        ):
+            dataset.download()
+        return dataset
+
+    def test_a_failed_season_raises_and_caches_nothing(self):
+        def side_effect(dates, **_kwargs):
+            if dates == 2020:
+                raise ConnectionError("upstream timed out")
+            return self._season_frame(dates)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self._run_download(side_effect)
+
+        message = str(ctx.exception)
+        self.assertIn("2020", message)
+        self.assertIn("ConnectionError", message)
+        self.assertEqual(os.listdir(self.cache_dir), [], "a partial download was cached")
+
+    def test_a_complete_download_is_cached(self):
+        dataset = self._run_download(lambda dates, **_kwargs: self._season_frame(dates))
+        self.assertTrue(os.path.exists(dataset.data_file))
+        cached = pd.read_csv(dataset.data_file)
+        self.assertEqual(len(cached), 9)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A transient fetch failure for one season is printed and swallowed, and the short result is then **written to the cache**. Every later run reads a dataset with an entire season missing and has no way to know.

I hit this for real while benchmarking. My cached 2015-2022 college football dataset had 6,432 games:

```
{2015: 979, 2016: 981, 2017: 976, 2018: 971, 2019: 977, 2020: 575, 2022: 973}
```

No 2021. Requesting 2021 on its own returns 989 games, and re-downloading the full range returns 7,421. One season had failed to fetch, months of benchmark runs read the truncated cache, and nothing anywhere said so.

### Cause

```python
except Exception as e:
    print(f"Error fetching data for year {year}: {e}")
    print("Continuing with next year...")
    continue
...
if all_games.empty:
    raise ValueError("No games data was retrieved. ...")
```

Two silent paths:

1. A per-year exception prints to stdout and continues. The only guard, `all_games.empty`, fires just when *every* season fails, so 7 of 8 succeeding looks like success.
2. `if year_data is not None and not year_data.empty:` skips an empty season with no message at all.

The cache filename is keyed only on the requested range (`..._2015_2022.csv`), so the truncated file is indistinguishable from a good one and is preferred on every subsequent call.

### Fix

- Collect failed seasons and **raise** naming them, rather than continuing to a partial result.
- Never write the cache when any season failed, so a re-run retries instead of inheriting the gap.
- Log a warning (through `elote.logging`, not `print`) when a season legitimately returns no games, and say so again at the end.

A partial dataset that looks complete is worse than an error, especially for a benchmark corpus where the missing season silently changes every number computed from it.

### Tests

- `test_a_failed_season_raises_and_caches_nothing` — one season raises `ConnectionError`; the call raises `RuntimeError` naming the year and the cause, and the cache directory is left empty.
- `test_a_complete_download_is_cached` — the happy path still caches all three seasons.

Both drive `download()` with a mocked `sportsdataverse`, so they need no network.

504 passed, 6 skipped. Lint clean.

Targets `release/v1.3.0`.
