### PR TITLE
Release v1.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ htmlcov/
 .venv/
 .benchmarks/
 .coverage*
-.uv.lock
+.uv.lockbuild/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+v1.3.1
+======
+
+A correctness release for two defects found while reproducing the v1.3.0 benchmark on real
+college football data.
+
+Bug fixes
+
+ * `KeenerCompetitor` no longer lets a competitor with a very thin schedule outrate one with a
+   full schedule. Dividing each row of the preference matrix by games played equalizes row
+   sums but not row concentration: a competitor with a single game puts all of its weight on
+   one opponent, and the dominant eigenvector reads that concentration as strength. On the
+   college football dataset the top five Keener ratings were teams that had played one or two
+   games. The games-played denominator now carries a prior of two pseudo-games
+   (`KeenerCompetitor._games_prior`), the same correction the Laplace-smoothed score share
+   already applies to a thin pairwise record. Keener ratings from v1.3.0 will change.
+ * `CollegeFootballDataset.download()` no longer caches a download that lost a season. A
+   per-year fetch failure was printed and swallowed, and the short result written to a cache
+   keyed only on the requested year range, so every later run silently read a dataset with a
+   season missing. Failed seasons are now collected and raised, nothing is written, and a
+   season that legitimately returns no games is reported through `elote.logging` rather than
+   `print`.
+
 v1.3.0
 ======
 

--- a/elote/competitors/keener.py
+++ b/elote/competitors/keener.py
@@ -30,8 +30,11 @@ against ``j`` across all their meetings.
    very large margins, which is what stops the method rewarding running up the score without
    limit.
 
-3. **Games-played normalization.** Row ``i`` is divided by the number of games ``i`` played,
-   so a competitor cannot accumulate rating merely by playing more often.
+3. **Games-played normalization.** Row ``i`` is divided by the number of games ``i`` played
+   plus a small prior, so a competitor cannot accumulate rating merely by playing more often,
+   and cannot accumulate it by playing barely at all either. The prior matters on a ragged
+   schedule: without it, a competitor's single game concentrates its entire row on one
+   opponent, which the eigenvector reads as strength.
 
 4. **Stabilization.** A small positive constant is added to every entry. Keener's own
    ``A + eps * E`` perturbation makes the matrix strictly positive, so Perron-Frobenius
@@ -88,6 +91,12 @@ class KeenerCompetitor(BaseCompetitor):
             at the population average.
         _perturbation (float): Keener's ``eps``, added to every matrix entry so the matrix is
             strictly positive and Perron-Frobenius applies. Default: 1e-4.
+        _games_prior (float): Pseudo-games added to the games-played denominator, shrinking a
+            competitor's average preference toward zero in proportion to how little evidence
+            backs it. Default: 2.0, matching the two pseudo-observations the Laplace-smoothed
+            score share already assumes. Without it, a competitor with a single game puts all
+            of its row weight on one opponent and the dominant eigenvector rewards that
+            concentration, so a one-game team can outrate an undefeated one.
         _expected_score_scale (float): Logistic scale applied to the log rating ratio by
             :meth:`expected_score`. Default: 1.0, which is the plain Keener share
             ``r_a / (r_a + r_b)``.
@@ -100,6 +109,7 @@ class KeenerCompetitor(BaseCompetitor):
     _minimum_rating: ClassVar[float] = 0.0
     _default_initial_rating: ClassVar[float] = 1.0
     _perturbation: ClassVar[float] = 1e-4
+    _games_prior: ClassVar[float] = 2.0
     _expected_score_scale: ClassVar[float] = 1.0
     _round_decimals: ClassVar[int] = 10
 
@@ -342,7 +352,15 @@ class KeenerCompetitor(BaseCompetitor):
 
         # Divide by games played, making each row the competitor's average preference per
         # game, so a longer schedule is not itself worth rating.
-        preferences = preferences / np.maximum(games, 1.0)[:, None]
+        #
+        # The denominator carries a prior of `_games_prior` pseudo-games. Dividing by the raw
+        # count equalizes row sums but not row *concentration*: a competitor with one game
+        # places all of its weight on a single opponent, and the dominant eigenvector rewards
+        # that, so a one-game team could outrate an undefeated one with a full schedule. The
+        # prior shrinks a thin row toward zero by a factor of g / (g + prior) and leaves a
+        # full schedule essentially untouched. It is the same correction the Laplace-smoothed
+        # score share above already applies to a thin pairwise record.
+        preferences = preferences / (np.maximum(games, 0.0) + cls._games_prior)[:, None]
 
         # Keener's eps * E perturbation: makes the matrix strictly positive, so its dominant
         # eigenvalue is simple and its eigenvector strictly positive. This is also what

--- a/elote/datasets/football.py
+++ b/elote/datasets/football.py
@@ -11,6 +11,7 @@ import pandas as pd
 from typing import List, Tuple, Dict, Any, Optional
 
 from elote.datasets.base import BaseDataset
+from elote.logging import logger
 
 # Bumped whenever the cached CSV's schema or the meaning of its columns changes, so an
 # existing cache written by an older version of this module cannot be reused silently.
@@ -91,6 +92,9 @@ class CollegeFootballDataset(BaseDataset):
         all_games = pd.DataFrame()
 
         # Download data for each year
+        failed_years: Dict[int, str] = {}
+        empty_years: List[int] = []
+
         for year in range(self.start_year, self.end_year + 1):
             print(f"Fetching data for {year}...")
             try:
@@ -104,17 +108,40 @@ class CollegeFootballDataset(BaseDataset):
                     return_as_pandas=True,
                 )
 
-                if year_data is not None and not year_data.empty:
-                    # Keep only completed games
-                    year_data = year_data[year_data["status_type_completed"] == True]  # noqa: E712
-                    all_games = pd.concat([all_games, year_data], ignore_index=True)
-            except Exception as e:
-                print(f"Error fetching data for year {year}: {e}")
-                print("Continuing with next year...")
-                continue
+                if year_data is None or year_data.empty:
+                    empty_years.append(year)
+                    logger.warning("Season %d returned no games from the upstream feed.", year)
+                    continue
+
+                # Keep only completed games
+                year_data = year_data[year_data["status_type_completed"] == True]  # noqa: E712
+                all_games = pd.concat([all_games, year_data], ignore_index=True)
+            except Exception as e:  # noqa: BLE001 - reported below, never swallowed
+                failed_years[year] = f"{type(e).__name__}: {e}"
+                logger.warning("Fetching season %d failed: %s", year, failed_years[year])
+
+        if failed_years:
+            # A partial download must never be cached. The cache is keyed only by the
+            # requested year range, so writing a short result here would make every later
+            # run silently read a dataset with a season missing, with nothing to signal it.
+            detail = "; ".join(f"{year} ({reason})" for year, reason in sorted(failed_years.items()))
+            raise RuntimeError(
+                f"Failed to fetch {len(failed_years)} of "
+                f"{self.end_year - self.start_year + 1} requested seasons: {detail}. "
+                "Nothing was cached; re-run to retry."
+            )
 
         if all_games.empty:
             raise ValueError("No games data was retrieved. Check your internet connection or try again later.")
+
+        if empty_years:
+            logger.warning(
+                "Seasons with no games in the feed: %s. The cached dataset covers %d-%d "
+                "but does not contain these seasons.",
+                ", ".join(str(year) for year in empty_years),
+                self.start_year,
+                self.end_year,
+            )
 
         all_games = self._prepare_games(all_games)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "elote"
-version = "1.3.0"
+version = "1.3.1"
 description = "Python module for rating bouts (like with Elo Rating)"
 readme = "README.md"
 authors = [

--- a/tests/test_KeenerCompetitor.py
+++ b/tests/test_KeenerCompetitor.py
@@ -287,5 +287,74 @@ class TestKeenerArena(unittest.TestCase):
         self.assertEqual(len(arena.history.bouts), 1)
 
 
+class TestKeenerSmallSampleShrinkage(unittest.TestCase):
+    """The games-played denominator carries a prior so thin schedules cannot dominate."""
+
+    def _round_robin(self, names, repeats=2):
+        strength = {name: 40 - 5 * i for i, name in enumerate(names)}
+        competitors = {name: KeenerCompetitor() for name in names}
+        for _ in range(repeats):
+            for i, a in enumerate(names):
+                for b in names[i + 1:]:
+                    competitors[a].beat(competitors[b], scores=(strength[a], strength[b]))
+        return competitors
+
+    def test_thin_schedule_does_not_outrate_a_full_one(self):
+        """A one-game competitor must not outrate an undefeated one with a full schedule.
+
+        Dividing each row of the preference matrix by games played equalizes row sums but not
+        row concentration: a single game puts all of a competitor's weight on one opponent,
+        and the dominant eigenvector reads that concentration as strength.
+        """
+        names = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"]
+        competitors = self._round_robin(names)
+
+        cameo = KeenerCompetitor()
+        cameo.beat(competitors["Foxtrot"], scores=(21, 20))
+
+        alpha = competitors["Alpha"]
+        self.assertEqual(alpha.num_games, 10)
+        self.assertEqual(cameo.num_games, 1)
+        self.assertGreater(
+            alpha.rating,
+            cameo.rating,
+            f"one-game competitor rated {cameo.rating:.4f} over undefeated {alpha.rating:.4f}",
+        )
+
+        ordered = sorted(names, key=lambda n: -competitors[n].rating)
+        self.assertEqual(ordered[:4], ["Alpha", "Bravo", "Charlie", "Delta"])
+
+    def test_prior_leaves_a_full_schedule_essentially_unchanged(self):
+        """The prior shrinks thin rows; it must not meaningfully move a well-played group."""
+        names = ["Alpha", "Bravo", "Charlie", "Delta"]
+
+        def fit(prior):
+            original = KeenerCompetitor._games_prior
+            KeenerCompetitor._games_prior = prior
+            try:
+                competitors = self._round_robin(names, repeats=10)
+                return [competitors[n].rating for n in names]
+            finally:
+                KeenerCompetitor._games_prior = original
+
+        with_prior = fit(2.0)
+        without_prior = fit(0.0)
+
+        self.assertEqual(sorted(with_prior, reverse=True), with_prior)
+        for prior_rating, raw_rating in zip(with_prior, without_prior, strict=True):
+            self.assertLess(
+                abs(prior_rating - raw_rating),
+                0.05,
+                f"prior moved a 30-game rating from {raw_rating:.4f} to {prior_rating:.4f}",
+            )
+
+    def test_ratings_still_average_one(self):
+        """The documented normalization survives the change."""
+        competitors = self._round_robin(["Alpha", "Bravo", "Charlie", "Delta"])
+        ratings = [c.rating for c in competitors.values()]
+        self.assertAlmostEqual(sum(ratings) / len(ratings), 1.0, places=9)
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_KeenerCompetitor_known_values.py
+++ b/tests/test_KeenerCompetitor_known_values.py
@@ -9,8 +9,14 @@ Recall the construction for a connected group, with ``S_ij`` the points ``i`` sc
 
     a_ij = (S_ij + 1) / (S_ij + S_ji + 2)                  Laplace-smoothed score share
     h(x) = 1/2 + 1/2 * sgn(x - 1/2) * sqrt(|2x - 1|)       Keener's skew transform
-    H_ij = h(a_ij) / games_i + eps                         row-normalized, eps = 1e-4
+    H_ij = h(a_ij) / (games_i + prior) + eps               row-normalized, eps = 1e-4
     r    = dominant eigenvector of H, scaled to mean 1.0
+
+The shipped default carries ``prior = _games_prior = 2.0``, which keeps a competitor with a
+very thin schedule from concentrating its whole row on one opponent. The reference cases in
+:class:`TestKeenerKnownValues` pin the prior-free construction (``prior = 0``), because that
+is the form the closed solutions below were derived for;
+:class:`TestKeenerKnownValuesWithDefaultPrior` pins the shipped default separately.
 
 Ratings are canonicalized to ``_round_decimals`` (10) places, so assertions use 9 places.
 """
@@ -32,6 +38,15 @@ def _skew(share):
 
 
 class TestKeenerKnownValues(unittest.TestCase):
+    """Reference values for the prior-free construction the closed forms were derived for."""
+
+    def setUp(self):
+        self._original_prior = KeenerCompetitor._games_prior
+        KeenerCompetitor._games_prior = 0.0
+
+    def tearDown(self):
+        KeenerCompetitor._games_prior = self._original_prior
+
     def test_single_scored_game_matches_the_two_by_two_closed_form(self):
         """One 35-3 game between two competitors.
 
@@ -140,6 +155,56 @@ class TestKeenerKnownValues(unittest.TestCase):
         self.assertAlmostEqual(a.rating, 1.67957399744031952, places=PLACES)
         self.assertAlmostEqual(b.rating, 0.86984806605940995, places=PLACES)
         self.assertAlmostEqual(c.rating, 0.45057793650027053, places=PLACES)
+
+
+
+class TestKeenerKnownValuesWithDefaultPrior(unittest.TestCase):
+    """Reference values for the shipped default, ``_games_prior = 2.0``."""
+
+    def test_single_scored_game_matches_the_two_by_two_closed_form(self):
+        """The same 35-3 game, with the games prior in the denominator.
+
+        Both competitors played one game, so each row is divided by ``1 + 2 = 3``:
+
+            H = [[eps, p], [q, eps]]  with  p = h(0.9)/3 + eps, q = h(0.1)/3 + eps.
+
+        The shape is unchanged, so the dominant eigenvector is still proportional to
+        ``(sqrt(p), sqrt(q))`` and scaling to mean 1.0 over n = 2 gives the same expression.
+        The prior cancels in a two-competitor group where both played the same number of
+        games, which is exactly what it should do: it corrects *relative* thinness.
+        """
+        prior = KeenerCompetitor._games_prior
+        self.assertEqual(prior, 2.0)
+
+        p = _skew(0.9) / (1.0 + prior) + EPS
+        q = _skew(0.1) / (1.0 + prior) + EPS
+        root_p, root_q = math.sqrt(p), math.sqrt(q)
+        expected_a = 2.0 * root_p / (root_p + root_q)
+        expected_b = 2.0 * root_q / (root_p + root_q)
+
+        a, b = KeenerCompetitor(), KeenerCompetitor()
+        a.beat(b, scores=(35.0, 3.0))
+
+        self.assertAlmostEqual(a.rating, expected_a, places=PLACES)
+        self.assertAlmostEqual(b.rating, expected_b, places=PLACES)
+
+    def test_prior_demotes_a_competitor_with_a_thinner_schedule(self):
+        """Two competitors with identical per-game records, one with a longer schedule.
+
+        Both beat their opponents by the same margin every time, so their average preference
+        is identical and the prior is the only thing separating them. The one with more
+        evidence behind that average rates higher.
+        """
+        opponents = [KeenerCompetitor() for _ in range(5)]
+        busy, quiet = KeenerCompetitor(), KeenerCompetitor()
+
+        for opponent in opponents:
+            busy.beat(opponent, scores=(30.0, 10.0))
+        quiet.beat(opponents[0], scores=(30.0, 10.0))
+
+        self.assertEqual(busy.num_games, 5)
+        self.assertEqual(quiet.num_games, 1)
+        self.assertGreater(busy.rating, quiet.rating)
 
 
 if __name__ == "__main__":

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1069,5 +1069,69 @@ class TestDatasetUtils(unittest.TestCase):
         self.assertIn(skipped_message, captured.output)
 
 
+
+class TestCollegeFootballPartialDownload(unittest.TestCase):
+    """A season that fails to fetch must not be silently cached.
+
+    The cache file is keyed only by the requested year range, so writing a short result
+    after a transient failure makes every later run read a dataset with a season missing
+    and nothing to signal it.
+    """
+
+    def setUp(self):
+        self.cache_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.cache_dir, True)
+
+    @staticmethod
+    def _season_frame(year, rows=3):
+        return pd.DataFrame(
+            {
+                "start_date": [f"{year}-09-0{i + 1}T17:00Z" for i in range(rows)],
+                "home_display_name": [f"Home {year} {i}" for i in range(rows)],
+                "away_display_name": [f"Away {year} {i}" for i in range(rows)],
+                "home_score": [20 + i for i in range(rows)],
+                "away_score": [10 + i for i in range(rows)],
+                "neutral_site": [False] * rows,
+                "status_type_completed": [True] * rows,
+            }
+        )
+
+    def _run_download(self, schedule_side_effect):
+        from elote.datasets.football import CollegeFootballDataset
+
+        dataset = CollegeFootballDataset(cache_dir=self.cache_dir, start_year=2019, end_year=2021)
+        fake_cfb = MagicMock()
+        fake_cfb.espn_cfb_schedule.side_effect = schedule_side_effect
+        fake_pkg = MagicMock()
+        fake_pkg.cfb = fake_cfb
+        # `import sportsdataverse.cfb as cfb` resolves the submodule from sys.modules.
+        with patch.dict(
+            "sys.modules",
+            {"sportsdataverse": fake_pkg, "sportsdataverse.cfb": fake_cfb},
+        ):
+            dataset.download()
+        return dataset
+
+    def test_a_failed_season_raises_and_caches_nothing(self):
+        def side_effect(dates, **_kwargs):
+            if dates == 2020:
+                raise ConnectionError("upstream timed out")
+            return self._season_frame(dates)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self._run_download(side_effect)
+
+        message = str(ctx.exception)
+        self.assertIn("2020", message)
+        self.assertIn("ConnectionError", message)
+        self.assertEqual(os.listdir(self.cache_dir), [], "a partial download was cached")
+
+    def test_a_complete_download_is_cached(self):
+        dataset = self._run_download(lambda dates, **_kwargs: self._season_frame(dates))
+        self.assertTrue(os.path.exists(dataset.data_file))
+        cached = pd.read_csv(dataset.data_file)
+        self.assertEqual(len(cached), 9)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_score_channel.py
+++ b/tests/test_score_channel.py
@@ -331,11 +331,11 @@ class TestDatasetScoreForwarding(unittest.TestCase):
         """Pinned literals for both paths of the other score-consuming system."""
         self.assertEqual(
             _leaderboard(_trained(KeenerCompetitor, SCORED_ROWS)),
-            {"Steelers": 1.5088623362, "Ravens": 0.9649085365, "Browns": 0.923455846, "Bengals": 0.6027732813},
+            {"Steelers": 1.5779221429, "Ravens": 0.9983714654, "Browns": 0.860490018, "Bengals": 0.5632163737},
         )
         self.assertEqual(
             _leaderboard(_trained(KeenerCompetitor, SCORED_ROWS, score_keys=SCORE_KEYS)),
-            {"Steelers": 1.7295652954, "Ravens": 0.9585153377, "Browns": 0.9169460231, "Bengals": 0.3949733438},
+            {"Steelers": 1.7971469679, "Ravens": 0.9883138165, "Browns": 0.8486487294, "Bengals": 0.3658904862},
         )
 
     def test_scores_are_inert_for_a_system_that_ignores_them(self):


### PR DESCRIPTION
Supersedes #156 and #157, which targeted the now-merged `release/v1.3.0` branch. Same two fixes, rebased onto `master` and versioned as **v1.3.1**, ready to tag and release.

Both were found by reproducing the v1.3.0 benchmark on real college football data for the blog post about it.

---

### 1. Keener rated one-game teams at the top

Keener's top five on the college football dataset were teams that had played **one or two games**:

```
St Francis (PA) Red Flash        rating=5.2904  games=1
East Tennessee St. Buccaneers    rating=4.4304  games=1
Dayton Flyers                    rating=4.3657  games=1
```

Alabama played 76.

`_preference_matrix` divides row `i` by games played, which equalizes row *sums* but not row *concentration*. One game puts all of a competitor's weight on a single opponent, so its rating comes out near that opponent's, while a 76-game schedule gets an average over 76 opponents. The dominant eigenvector rewards the concentration.

Minimal case, a six-team double round robin plus one team that played once and beat the *worst* team 21-20:

```
Cameo   1.5674   1 game    1-0
Alpha   1.2606  10 games  10-0
```

**Fix:** divide by `games + _games_prior` (default 2.0). A thin row shrinks by `g / (g + 2)`; a full schedule is essentially unmoved. This is the same correction the Laplace-smoothed score share one step earlier already applies, which is where the 2 comes from.

After: top five becomes Alabama, San José St, Ohio State, LSU, Wisconsin, and accuracy improves 0.6481 to 0.6568.

The existing reference-value tests were derived for the prior-free construction, so that class now pins `_games_prior = 0.0` and keeps checking Keener's published closed form; a new class pins the shipped default, deriving its expectations independently.

**Keener ratings from v1.3.0 will change.** Noted in the changelog.

---

### 2. A failed season download was cached silently

My cached 2015-2022 dataset had 6,432 games:

```
{2015: 979, 2016: 981, 2017: 976, 2018: 971, 2019: 977, 2020: 575, 2022: 973}
```

No 2021. Requesting 2021 alone returns 989; re-downloading the full range returns 7,421. One season had failed to fetch months earlier, and the truncated result was written to a cache keyed only on the requested year range, so every subsequent run read it in preference to retrying.

The per-year `except Exception` printed and continued, and the only guard (`all_games.empty`) fires just when *every* season fails. Seven of eight succeeding looked like success.

**Fix:** collect failed seasons, raise naming them and the cause, and write nothing so a re-run retries. A season that legitimately returns no games is warned through `elote.logging` instead of being skipped in silence.

This one mattered: every benchmark number I had computed was over seven seasons while reporting eight.

---

509 passed, 6 skipped. Lint clean.
