### PR TITLE
Release v1.3.2: forward dataset timestamps, add walk-forward evaluation

### DIFF
--- a/elote/__init__.py
+++ b/elote/__init__.py
@@ -67,6 +67,13 @@ from elote.datasets.utils import train_arena_with_dataset, evaluate_arena_with_d
 
 # Core analysis modules - always available
 from elote.benchmark import evaluate_competitor, benchmark_competitors
+from elote.evaluation import (
+    WalkForwardReport,
+    TuningResult,
+    group_by_period,
+    walk_forward,
+    tune,
+)
 from elote.visualization import (
     plot_rating_system_comparison,
     plot_optimized_accuracy_comparison,
@@ -108,6 +115,11 @@ __all__ = [
     # Benchmarking
     "evaluate_competitor",
     "benchmark_competitors",
+    "WalkForwardReport",
+    "TuningResult",
+    "group_by_period",
+    "walk_forward",
+    "tune",
     # Visualization
     "plot_rating_system_comparison",
     "plot_optimized_accuracy_comparison",

--- a/elote/datasets/utils.py
+++ b/elote/datasets/utils.py
@@ -105,26 +105,31 @@ def train_arena_with_dataset(
         end_idx = min(start_idx + batch_size, len(sorted_data))
         batch = sorted_data[start_idx:end_idx]
 
-        # Process each matchup
-        for a, b, outcome, _, attributes in batch:
+        # Process each matchup. The row's timestamp is forwarded as match_time: the
+        # time-aware systems (Whole-History Rating's per-day curve, Glicko and Glicko-2's
+        # inactivity inflation, DWZ's age-dependent development coefficient) have no other
+        # source for it, and without it every row in a dataset looks simultaneous.
+        for a, b, outcome, when, attributes in batch:
             scores = None if score_keys is None else _scores_from_attributes(attributes, score_keys)
 
             if outcome == 1.0:
                 # A wins
                 if scores is None:
-                    arena.matchup(a, b, attributes=attributes)
+                    arena.matchup(a, b, attributes=attributes, match_time=when)
                 else:
-                    arena.matchup(a, b, attributes=attributes, outcome=1.0, scores=scores)
+                    arena.matchup(a, b, attributes=attributes, match_time=when, outcome=1.0, scores=scores)
             elif outcome == 0.0:
                 # B wins. The call is reversed so b is the winner, so the score pair has to
                 # be reversed with it to stay in the arena's caller order.
                 if scores is None:
-                    arena.matchup(b, a, attributes=attributes)
+                    arena.matchup(b, a, attributes=attributes, match_time=when)
                 else:
-                    arena.matchup(b, a, attributes=attributes, outcome=1.0, scores=(scores[1], scores[0]))
+                    arena.matchup(
+                        b, a, attributes=attributes, match_time=when, outcome=1.0, scores=(scores[1], scores[0])
+                    )
             else:
                 # Draw
-                arena.matchup(a, b, attributes=attributes, outcome=0.5, scores=scores)
+                arena.matchup(a, b, attributes=attributes, match_time=when, outcome=0.5, scores=scores)
 
         # Report progress
         if progress_callback is not None:

--- a/elote/evaluation.py
+++ b/elote/evaluation.py
@@ -1,0 +1,265 @@
+"""Walk-forward evaluation and hyperparameter search for rating systems.
+
+:func:`~elote.benchmark.evaluate_competitor` trains on one split and then predicts a held-out
+split with **frozen** ratings. That answers "how well do these ratings survive going stale",
+which is a real question but rarely the one being asked. The usual question is how a system
+performs in the way it would actually be used: predict the next round of results from
+everything that has happened so far, then fold those results in and step forward.
+
+This module provides that protocol, the metrics that can see a system's calibration as well
+as its picks, and a grid search over competitor parameters.
+
+Example:
+    >>> from elote import EloCompetitor, walk_forward, group_by_period
+    >>> periods = group_by_period(rows)                       # doctest: +SKIP
+    >>> report = walk_forward(EloCompetitor, periods)         # doctest: +SKIP
+    >>> report.accuracy, report.log_loss                      # doctest: +SKIP
+"""
+
+import math
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from itertools import product
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Type
+
+from elote.arenas.lambda_arena import LambdaArena
+from elote.competitors.base import BaseCompetitor
+from elote.datasets.utils import train_arena_with_dataset
+from elote.logging import logger
+
+__all__ = ["WalkForwardReport", "TuningResult", "group_by_period", "walk_forward", "tune"]
+
+# A dataset row, as produced by every dataset in :mod:`elote.datasets`.
+Row = Tuple[Any, Any, float, Optional[datetime], Optional[Dict[str, Any]]]
+
+_PROBABILITY_EPS = 1e-12
+
+
+@dataclass(frozen=True)
+class WalkForwardReport:
+    """Metrics from a walk-forward run.
+
+    Attributes:
+        predictions: Bouts that were both scored and predictable.
+        skipped: Bouts skipped because a competitor had not been seen yet.
+        draws: Drawn bouts, excluded from every metric below.
+        accuracy: Fraction of predictions on the correct side of 0.5.
+        log_loss: Mean negative log likelihood. Sees calibration; accuracy does not.
+        brier: Mean squared error of the predicted probability.
+        by_period: ``(period_index, predictions, accuracy)`` per scored period.
+    """
+
+    predictions: int
+    skipped: int
+    draws: int
+    accuracy: float
+    log_loss: float
+    brier: float
+    by_period: Tuple[Tuple[int, int, float], ...] = field(default=())
+
+    def __str__(self) -> str:
+        return (
+            f"{self.predictions} predictions: accuracy {self.accuracy:.4f}, "
+            f"log loss {self.log_loss:.4f}, Brier {self.brier:.4f}"
+        )
+
+
+@dataclass(frozen=True)
+class TuningResult:
+    """One point of a :func:`tune` grid search."""
+
+    params: Dict[str, Any]
+    report: WalkForwardReport
+
+    def __str__(self) -> str:
+        rendered = ", ".join(f"{k}={v}" for k, v in sorted(self.params.items()))
+        return f"{rendered}: {self.report}"
+
+
+def _period_key(when: Optional[datetime]) -> Tuple[int, int]:
+    if when is None:
+        return (0, 0)
+    day = when.date() if isinstance(when, datetime) else when
+    if not isinstance(day, date):
+        return (0, 0)
+    iso = day.isocalendar()
+    return (iso[0], iso[1])
+
+
+def group_by_period(
+    rows: Iterable[Row],
+    key: Optional[Callable[[Row], Any]] = None,
+) -> List[List[Row]]:
+    """Group dataset rows into chronologically ordered periods.
+
+    A period is the unit of "predict, then learn": everything inside one is predicted before
+    any of it is used for fitting, which is what stops a result informing a bet placed on the
+    same afternoon.
+
+    Args:
+        rows: Dataset rows, in any order.
+        key: Maps a row to its period. Defaults to the ISO calendar week of the row's
+            timestamp, which suits weekly league sports. Rows without a usable timestamp are
+            collected into one leading period.
+
+    Returns:
+        A list of periods, each a list of rows, ordered by period key.
+    """
+    grouping = key if key is not None else (lambda row: _period_key(row[3]))
+    buckets: "OrderedDict[Any, List[Row]]" = OrderedDict()
+    for row in rows:
+        buckets.setdefault(grouping(row), []).append(row)
+    return [buckets[k] for k in sorted(buckets)]
+
+
+def walk_forward(
+    competitor_class: Type[BaseCompetitor],
+    periods: Sequence[Sequence[Row]],
+    *,
+    competitor_params: Optional[Dict[str, Any]] = None,
+    base_competitor_kwargs: Optional[Dict[str, Any]] = None,
+    comparison_function: Optional[Callable[..., Any]] = None,
+    score_keys: Optional[Tuple[str, str]] = None,
+    warmup: int = 0,
+) -> WalkForwardReport:
+    """Predict each period from everything before it, then learn that period.
+
+    Args:
+        competitor_class: The rating system to evaluate.
+        periods: Ordered periods of dataset rows, as produced by :func:`group_by_period`.
+        competitor_params: Class variables to set for the duration of the run, without the
+            leading underscore. ``{"w2": 100.0}`` sets ``_w2``.
+        base_competitor_kwargs: Constructor keyword arguments for every competitor.
+        comparison_function: Arena comparison function. Defaults to one that reports the
+            recorded outcome, which is what a dataset row already carries.
+        score_keys: ``(a_score_key, b_score_key)`` naming each row's two point scores, for
+            the margin-aware systems.
+        warmup: Leading periods used for fitting but not scored, so a system is not judged
+            on predictions made with no history.
+
+    Returns:
+        WalkForwardReport: Metrics over every scored, predictable bout.
+
+    Raises:
+        ValueError: If ``warmup`` is negative or not smaller than the number of periods.
+    """
+    if warmup < 0:
+        raise ValueError("warmup must be non-negative")
+    if periods and warmup >= len(periods):
+        raise ValueError(f"warmup ({warmup}) leaves no periods to score (have {len(periods)})")
+
+    comparison = comparison_function if comparison_function is not None else (lambda a, b, attributes=None: True)
+    arena = LambdaArena(
+        comparison,
+        base_competitor=competitor_class,
+        base_competitor_kwargs=dict(base_competitor_kwargs or {}),
+    )
+
+    overrides = {f"_{name}": value for name, value in (competitor_params or {}).items()}
+    originals = {name: getattr(competitor_class, name) for name in overrides if hasattr(competitor_class, name)}
+
+    predictions = skipped = draws = 0
+    log_loss_total = brier_total = 0.0
+    correct = 0
+    by_period: List[Tuple[int, int, float]] = []
+
+    try:
+        for name, value in overrides.items():
+            setattr(competitor_class, name, value)
+
+        for index, period in enumerate(periods):
+            scored = index >= warmup
+            period_correct = period_count = 0
+
+            if scored:
+                for a, b, outcome, _when, _attributes in period:
+                    if outcome is None:
+                        continue
+                    if outcome == 0.5:
+                        draws += 1
+                        continue
+                    if a not in arena.competitors or b not in arena.competitors:
+                        skipped += 1
+                        continue
+                    probability = arena.expected_score(a, b)
+                    probability = min(max(probability, _PROBABILITY_EPS), 1.0 - _PROBABILITY_EPS)
+                    actual = 1.0 if outcome > 0.5 else 0.0
+                    hit = (probability > 0.5) == (actual > 0.5)
+                    predictions += 1
+                    correct += hit
+                    period_correct += hit
+                    period_count += 1
+                    log_loss_total -= actual * math.log(probability) + (1.0 - actual) * math.log(1.0 - probability)
+                    brier_total += (probability - actual) ** 2
+
+            train_arena_with_dataset(arena, list(period), score_keys=score_keys)
+
+            if scored and period_count:
+                by_period.append((index, period_count, period_correct / period_count))
+    finally:
+        for name, value in originals.items():
+            setattr(competitor_class, name, value)
+        for name in overrides:
+            if name not in originals:
+                delattr(competitor_class, name)
+
+    if not predictions:
+        logger.warning("Walk-forward produced no scored predictions (skipped %d, draws %d).", skipped, draws)
+        return WalkForwardReport(0, skipped, draws, float("nan"), float("nan"), float("nan"), ())
+
+    return WalkForwardReport(
+        predictions=predictions,
+        skipped=skipped,
+        draws=draws,
+        accuracy=correct / predictions,
+        log_loss=log_loss_total / predictions,
+        brier=brier_total / predictions,
+        by_period=tuple(by_period),
+    )
+
+
+def tune(
+    competitor_class: Type[BaseCompetitor],
+    param_grid: Dict[str, Sequence[Any]],
+    periods: Sequence[Sequence[Row]],
+    *,
+    metric: str = "log_loss",
+    **walk_forward_kwargs: Any,
+) -> List[TuningResult]:
+    """Grid-search competitor parameters against a walk-forward run.
+
+    ``metric`` defaults to ``log_loss`` deliberately. Accuracy is a rank statistic: it only
+    asks which side of 0.5 a prediction landed on, so any parameter that changes confidence
+    without changing order is invisible to it. Pythagorean's exponent is exactly such a
+    parameter, and tuning it on accuracy reports every value as equally good.
+
+    Args:
+        competitor_class: The rating system to tune.
+        param_grid: Parameter names (without the leading underscore) to sequences of values.
+        periods: Ordered periods, as for :func:`walk_forward`.
+        metric: ``"log_loss"``, ``"brier"`` or ``"accuracy"``.
+        **walk_forward_kwargs: Forwarded to :func:`walk_forward`.
+
+    Returns:
+        Every combination, best first.
+
+    Raises:
+        ValueError: If ``metric`` is unknown or ``param_grid`` is empty.
+    """
+    if metric not in {"log_loss", "brier", "accuracy"}:
+        raise ValueError(f"unknown metric {metric!r}; expected 'log_loss', 'brier' or 'accuracy'")
+    if not param_grid:
+        raise ValueError("param_grid must not be empty")
+
+    names = sorted(param_grid)
+    results: List[TuningResult] = []
+    for values in product(*(param_grid[name] for name in names)):
+        params = dict(zip(names, values, strict=True))
+        report = walk_forward(competitor_class, periods, competitor_params=params, **walk_forward_kwargs)
+        logger.info("tune %s -> %s", params, report)
+        results.append(TuningResult(params=params, report=report))
+
+    higher_is_better = metric == "accuracy"
+    results.sort(key=lambda r: getattr(r.report, metric), reverse=higher_is_better)
+    return results

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -22,6 +22,7 @@ from elote import (
     evaluate_arena_with_dataset,
     train_and_evaluate_arena,
     list_available_datasets,
+    WholeHistoryRatingCompetitor,
 )
 from elote.arenas.base import Bout, History
 
@@ -1131,6 +1132,67 @@ class TestCollegeFootballPartialDownload(unittest.TestCase):
         self.assertTrue(os.path.exists(dataset.data_file))
         cached = pd.read_csv(dataset.data_file)
         self.assertEqual(len(cached), 9)
+
+
+
+class TestTrainingForwardsMatchTime(unittest.TestCase):
+    """A dataset row's timestamp must reach the competitors, not just the sort.
+
+    Whole-History Rating keeps one latent rating per playing day, Glicko and Glicko-2 inflate
+    rating deviation for time since last match, and DWZ's development coefficient depends on
+    age at the time of the match. None of them has any other source for the date, so dropping
+    it makes every row in a dataset look simultaneous.
+    """
+
+    class _RecordingArena:
+        def __init__(self):
+            self.match_times = []
+
+        def matchup(self, a, b, attributes=None, match_time=None, outcome=None, scores=None):
+            self.match_times.append(match_time)
+
+    def _rows(self):
+        return [
+            ("A", "B", 1.0, datetime.datetime(2020, 1, 6), None),
+            ("C", "D", 0.0, datetime.datetime(2020, 2, 6), None),
+            ("E", "F", 0.5, datetime.datetime(2020, 3, 6), None),
+        ]
+
+    def test_match_time_is_forwarded_for_every_outcome(self):
+        arena = self._RecordingArena()
+        train_arena_with_dataset(arena, self._rows())
+
+        self.assertEqual(
+            arena.match_times,
+            [
+                datetime.datetime(2020, 1, 6),
+                datetime.datetime(2020, 2, 6),
+                datetime.datetime(2020, 3, 6),
+            ],
+        )
+
+    def test_rows_without_a_timestamp_still_train(self):
+        arena = self._RecordingArena()
+        train_arena_with_dataset(arena, [("A", "B", 1.0, None, None)])
+        self.assertEqual(arena.match_times, [None])
+
+    def test_whr_builds_one_rating_per_playing_day(self):
+        """End to end: distinct dates must produce distinct days in the fitted curve."""
+        arena = LambdaArena(lambda a, b: True, base_competitor=WholeHistoryRatingCompetitor)
+        train_arena_with_dataset(
+            arena,
+            [
+                ("A", "B", 1.0, datetime.datetime(2020, 1, 6), None),
+                ("A", "B", 1.0, datetime.datetime(2020, 6, 6), None),
+                ("A", "B", 1.0, datetime.datetime(2020, 11, 6), None),
+            ],
+        )
+        history = arena.competitors["A"].rating_history()
+        self.assertEqual(len(history), 3, f"expected three playing days, got {history}")
+        self.assertEqual(
+            [day for day, _rating in history],
+            [datetime.date(2020, 1, 6), datetime.date(2020, 6, 6), datetime.date(2020, 11, 6)],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,169 @@
+"""Tests for walk-forward evaluation and tuning."""
+
+import datetime
+import math
+import unittest
+
+from elote import (
+    EloCompetitor,
+    PythagoreanCompetitor,
+    group_by_period,
+    tune,
+    walk_forward,
+)
+
+
+def _row(a, b, outcome, when, scores=None):
+    attributes = None
+    if scores is not None:
+        attributes = {"home_score": scores[0], "away_score": scores[1]}
+    return (a, b, outcome, when, attributes)
+
+
+def _season(weeks=6, teams=("A", "B", "C", "D")):
+    """A deterministic schedule where A > B > C > D, one round of games per week."""
+    start = datetime.datetime(2020, 1, 6)
+    strength = {name: len(teams) - i for i, name in enumerate(teams)}
+    periods = []
+    for week in range(weeks):
+        when = start + datetime.timedelta(days=7 * week)
+        rows = []
+        for i, home in enumerate(teams):
+            for away in teams[i + 1:]:
+                margin = 7 * (strength[home] - strength[away])
+                rows.append(_row(home, away, 1.0, when, (14 + margin, 14)))
+        periods.append(rows)
+    return periods
+
+
+class TestGroupByPeriod(unittest.TestCase):
+    def test_groups_by_iso_week_in_order(self):
+        rows = [
+            _row("A", "B", 1.0, datetime.datetime(2020, 1, 15)),
+            _row("C", "D", 1.0, datetime.datetime(2020, 1, 6)),
+            _row("E", "F", 1.0, datetime.datetime(2020, 1, 7)),
+        ]
+        periods = group_by_period(rows)
+        self.assertEqual(len(periods), 2)
+        self.assertEqual(len(periods[0]), 2)  # the two games in the earlier week
+        self.assertEqual(periods[1][0][0], "A")
+
+    def test_custom_key(self):
+        rows = [_row(f"A{i}", f"B{i}", 1.0, None) for i in range(4)]
+        periods = group_by_period(rows, key=lambda row: row[0][-1])
+        self.assertEqual(len(periods), 4)
+
+    def test_rows_without_timestamps_form_one_leading_period(self):
+        rows = [
+            _row("A", "B", 1.0, None),
+            _row("C", "D", 1.0, datetime.datetime(2020, 6, 1)),
+        ]
+        periods = group_by_period(rows)
+        self.assertEqual(len(periods), 2)
+        self.assertIsNone(periods[0][0][3])
+
+
+class TestWalkForward(unittest.TestCase):
+    def test_learns_a_separable_schedule(self):
+        report = walk_forward(EloCompetitor, _season(), warmup=1)
+        self.assertGreater(report.predictions, 0)
+        self.assertGreater(report.accuracy, 0.9)
+        self.assertLess(report.log_loss, 0.7)
+
+    def test_first_period_is_never_scored_when_warmed_up(self):
+        periods = _season()
+        with_warmup = walk_forward(EloCompetitor, periods, warmup=1)
+        without = walk_forward(EloCompetitor, periods, warmup=0)
+        self.assertEqual(without.predictions - with_warmup.predictions, 0)
+        # Nothing is predictable in period 0 either way: no competitor exists yet.
+        self.assertGreater(without.skipped, 0)
+
+    def test_no_lookahead_within_a_period(self):
+        """Every bout in a period is predicted before any of it is learned."""
+        periods = [
+            [_row("A", "B", 1.0, datetime.datetime(2020, 1, 6))],
+            # B beats A twice in one period; the second must not learn from the first.
+            [
+                _row("B", "A", 1.0, datetime.datetime(2020, 1, 13)),
+                _row("B", "A", 1.0, datetime.datetime(2020, 1, 13)),
+            ],
+        ]
+        report = walk_forward(EloCompetitor, periods, warmup=1)
+        self.assertEqual(report.predictions, 2)
+        # Both bouts saw identical ratings, so both predictions agree.
+        self.assertIn(report.accuracy, (0.0, 1.0))
+
+    def test_draws_are_excluded_and_counted(self):
+        periods = [
+            [_row("A", "B", 1.0, datetime.datetime(2020, 1, 6))],
+            [_row("A", "B", 0.5, datetime.datetime(2020, 1, 13))],
+        ]
+        report = walk_forward(EloCompetitor, periods, warmup=1)
+        self.assertEqual(report.draws, 1)
+        self.assertEqual(report.predictions, 0)
+        self.assertTrue(math.isnan(report.accuracy))
+
+    def test_unseen_competitors_are_skipped_not_invented(self):
+        periods = [
+            [_row("A", "B", 1.0, datetime.datetime(2020, 1, 6))],
+            [_row("Y", "Z", 1.0, datetime.datetime(2020, 1, 13))],
+        ]
+        report = walk_forward(EloCompetitor, periods, warmup=1)
+        self.assertEqual(report.skipped, 1)
+        self.assertEqual(report.predictions, 0)
+
+    def test_competitor_params_are_restored_afterwards(self):
+        before = PythagoreanCompetitor._exponent
+        walk_forward(PythagoreanCompetitor, _season(), warmup=1, competitor_params={"exponent": 9.0})
+        self.assertEqual(PythagoreanCompetitor._exponent, before)
+
+    def test_rejects_a_warmup_that_leaves_nothing_to_score(self):
+        periods = _season(weeks=2)
+        with self.assertRaises(ValueError):
+            walk_forward(EloCompetitor, periods, warmup=2)
+        with self.assertRaises(ValueError):
+            walk_forward(EloCompetitor, periods, warmup=-1)
+
+
+class TestTune(unittest.TestCase):
+    def test_orders_results_by_metric(self):
+        results = tune(
+            PythagoreanCompetitor,
+            {"exponent": [1.0, 2.0, 8.0]},
+            _season(),
+            metric="log_loss",
+            warmup=1,
+        )
+        self.assertEqual(len(results), 3)
+        losses = [r.report.log_loss for r in results]
+        self.assertEqual(losses, sorted(losses))
+
+    def test_accuracy_cannot_separate_the_pythagorean_exponent(self):
+        """The exponent changes confidence, never which side is favoured.
+
+        `PF**k / (PF**k + PA**k)` is monotone in `PF/PA` for any positive k, and the log5
+        combination exceeds 0.5 exactly when one rating exceeds the other, so k cancels out
+        of every binary decision. Tuning it on accuracy therefore reports a flat surface,
+        which is the reason `tune` defaults to log loss.
+        """
+        results = tune(
+            PythagoreanCompetitor,
+            {"exponent": [1.0, 2.0, 8.0]},
+            _season(),
+            metric="accuracy",
+            warmup=1,
+        )
+        accuracies = {round(r.report.accuracy, 12) for r in results}
+        self.assertEqual(len(accuracies), 1)
+        log_losses = {round(r.report.log_loss, 12) for r in results}
+        self.assertGreater(len(log_losses), 1)
+
+    def test_rejects_unknown_metric_and_empty_grid(self):
+        with self.assertRaises(ValueError):
+            tune(EloCompetitor, {"k_factor": [16]}, _season(), metric="nonsense")
+        with self.assertRaises(ValueError):
+            tune(EloCompetitor, {}, _season())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two related changes, both found while benchmarking Whole-History Rating for a blog post.

---

## Bug: dataset training silently discarded every timestamp

`train_arena_with_dataset` unpacked each row's timestamp into `_` and used it **only for sorting**:

```python
for a, b, outcome, _, attributes in batch:
    ...
    arena.matchup(a, b, attributes=attributes)      # no match_time
```

Every time-aware rating system trained through the dataset helpers — which is the path `evaluate_competitor` and `benchmark_competitors` take — therefore saw a dataset in which every game happened at the same instant.

Whole-History Rating is the extreme case. Its whole model is one latent rating per playing day linked by a Wiener-process prior; with no dates, all 7,400 games collapse onto a single day and WHR degenerates into a worse Bradley-Terry. It doesn't error. It just quietly becomes a different, worse model.

Measured on eight seasons of college football, walk-forward:

| system | before | after | delta |
|---|---|---|---|
| **WHR** | 0.6595 | 0.7053 | **+0.0458** |
| Glicko-2 | 0.7040 | 0.7153 | +0.0113 |
| Glicko | 0.6977 | 0.7073 | +0.0096 |
| DWZ | 0.7005 | 0.7075 | +0.0070 |
| Elo (control, no time model) | 0.6921 | 0.6923 | +0.0002 |

Elo is the control and moves by 0.0002, which is a period-boundary artifact rather than a real change. Everything that models time improves in proportion to how much time it models. WHR goes from last of twelve to competitive.

Three regression tests: `match_time` is forwarded for wins, losses and draws; a row without a timestamp still trains; and end-to-end, three games on three distinct dates produce three days in WHR's fitted curve rather than one.

---

## Feature: `elote.evaluation`

I have now hand-rolled the same walk-forward loop four times for four different posts, which is a good sign it belongs in the library.

`evaluate_competitor` trains on one split and predicts a held-out split with **frozen** ratings. That measures how gracefully ratings survive going stale, which is a real question but rarely the one being asked, and it systematically favours systems that forget over systems that fit all of history.

```python
from elote import group_by_period, walk_forward, tune

periods = group_by_period(rows)                 # ISO week by default; pass your own key
report = walk_forward(EloCompetitor, periods, warmup=23)
report.accuracy, report.log_loss, report.brier
```

`walk_forward` predicts every bout in a period before learning any of it, so a result cannot inform a prediction made the same afternoon. It reports **log loss and Brier alongside accuracy**, skips competitors it has not seen rather than inventing them, and excludes and counts draws.

`tune` grid-searches parameters and **defaults to log loss, deliberately**:

```python
tune(WholeHistoryRatingCompetitor, {"w2": [10, 30, 100, 300]}, periods, warmup=23)
```

Accuracy is a rank statistic — it only asks which side of 0.5 you landed on — so any parameter that changes confidence without changing order is invisible to it. Pythagorean's exponent is exactly such a parameter: sweeping it from 1.0 to 10.0 gives *identical* accuracy to four decimals while log loss varies by a factor of two. There is a test pinning that, because it is the reason for the default.

Verified against the hand-rolled harness: Elo 0.6923 vs 0.6921 and Massey 0.7058 vs 0.7062, the 9-bout difference being January games that fall in an ISO-2015 week. The library's period-boundary cut is the more correct of the two.

13 new tests, including no-lookahead-within-a-period and parameter restoration. 525 passed, 6 skipped. Lint clean.

---

Note: WHR is meaningfully slower now, because it is finally doing the per-day fitting it was written to do.
