### PR TITLE
Resolve BlendedCompetitor legacy state through the competitor registry

### DIFF
--- a/.cursor/rules/implementing_competitors.mdc
+++ b/.cursor/rules/implementing_competitors.mdc
@@ -254,17 +254,15 @@ def _helper_method(self, value: float) -> float:
     return result
 ```
 
-## Step 5: Register Your Competitor (Optional)
+## Step 5: Registration (Nothing To Do)
 
-If you want your competitor to be usable with `BlendedCompetitor`, add it to the `competitor_types` dictionary in `elote/competitors/ensemble.py`:
+Subclassing `BaseCompetitor` registers your class automatically via `__init_subclass__`, so it is
+immediately resolvable by name through `BaseCompetitor.get_competitor_class` and usable with
+`BlendedCompetitor` and `from_state`. There is no separate type map to update.
 
 ```python
-from elote.competitors.my_new_competitor import MyNewCompetitor
-
-competitor_types = {
-    # Existing competitors...
-    "MyNewCompetitor": MyNewCompetitor,
-}
+BaseCompetitor.get_competitor_class("MyNewCompetitor")  # -> MyNewCompetitor
+"MyNewCompetitor" in BaseCompetitor.list_competitor_types()  # -> True
 ```
 
 ## Best Practices

--- a/elote/competitors/ensemble.py
+++ b/elote/competitors/ensemble.py
@@ -6,29 +6,9 @@ from elote.competitors.base import (
     InvalidStateException,
     MissMatchedCompetitorTypesException,
 )
-from elote import (
-    EloCompetitor,
-    ECFCompetitor,
-    DWZCompetitor,
-    GlickoCompetitor,
-    Glicko2Competitor,
-    TrueSkillCompetitor,
-    ColleyMatrixCompetitor,
-)
 from elote.logging import logger  # Import directly from the logging submodule
 
 T = TypeVar("T", bound="BlendedCompetitor")
-
-# Dictionary mapping competitor type names to their classes
-competitor_types = {
-    "EloCompetitor": EloCompetitor,
-    "ECFCompetitor": ECFCompetitor,
-    "DWZCompetitor": DWZCompetitor,
-    "GlickoCompetitor": GlickoCompetitor,
-    "Glicko2Competitor": Glicko2Competitor,
-    "TrueSkillCompetitor": TrueSkillCompetitor,
-    "ColleyMatrixCompetitor": ColleyMatrixCompetitor,
-}
 
 
 class BlendedCompetitor(BaseCompetitor):
@@ -264,21 +244,17 @@ class BlendedCompetitor(BaseCompetitor):
             competitors = []
             for comp_state in competitors_state:
                 comp_type_name = comp_state.get("type", "EloCompetitor")
-                comp_type = competitor_types.get(comp_type_name)
-
-                if comp_type is None:
-                    logger.error("Unknown competitor type found in legacy state: %s", comp_type_name)
-                    raise InvalidParameterException(f"Unknown competitor type: {comp_type_name}")
+                BaseCompetitor.get_competitor_class(comp_type_name)
 
                 comp_kwargs = comp_state.get("competitor_kwargs", {})
 
-                # Create a new competitor specification with just the initial parameters
-                competitors.append(
-                    {
-                        "type": comp_type_name,
-                        "competitor_kwargs": {"initial_rating": comp_kwargs.get("initial_rating", 400)},
-                    }
+                # Create a new competitor specification with just the initial parameters.
+                # Only forward an initial rating the state actually carries: not every
+                # rating system takes one.
+                initial_kwargs = (
+                    {"initial_rating": comp_kwargs["initial_rating"]} if "initial_rating" in comp_kwargs else {}
                 )
+                competitors.append({"type": comp_type_name, "competitor_kwargs": initial_kwargs})
 
             # Create the blended competitor
             blended = cls(competitors=competitors, blend_mode=blend_mode)
@@ -286,7 +262,7 @@ class BlendedCompetitor(BaseCompetitor):
             # Now update each sub-competitor with its full state
             for i, comp_state in enumerate(competitors_state):
                 comp_type_name = comp_state.get("type", "EloCompetitor")
-                comp_type = competitor_types.get(comp_type_name)
+                comp_type = BaseCompetitor.get_competitor_class(comp_type_name)
                 comp_kwargs = comp_state.get("competitor_kwargs", {})
 
                 # Replace the sub-competitor with one created from the full state

--- a/tests/test_BlendedCompetitor.py
+++ b/tests/test_BlendedCompetitor.py
@@ -1,6 +1,12 @@
+import inspect
 import unittest
-from elote import BlendedCompetitor, GlickoCompetitor
-from elote.competitors.base import MissMatchedCompetitorTypesException
+
+from elote import BlendedCompetitor, BradleyTerryCompetitor, EloCompetitor, GlickoCompetitor
+from elote.competitors.base import (
+    BaseCompetitor,
+    InvalidParameterException,
+    MissMatchedCompetitorTypesException,
+)
 
 
 class TestBlendedCompetitor(unittest.TestCase):
@@ -128,3 +134,54 @@ class TestBlendedCompetitor(unittest.TestCase):
                     r"BlendedCompetitor compositions .* cannot be co-mingled",
                 ):
                     getattr(player1, operation)(player2)
+
+
+class TestBlendedCompetitorLegacyState(unittest.TestCase):
+    """The legacy ``from_state`` shape resolves sub-competitors through the class registry."""
+
+    @staticmethod
+    def _legacy_state(*sub_states):
+        return {
+            "blend_mode": "mean",
+            "competitors": [{"type": type(c).__name__, "competitor_kwargs": c.export_state()} for c in sub_states],
+        }
+
+    @staticmethod
+    def _new_competitor(name):
+        competitor_class = BaseCompetitor.get_competitor_class(name)
+        if "initial_rating" in inspect.signature(competitor_class.__init__).parameters:
+            return competitor_class(initial_rating=1234)
+        return competitor_class()
+
+    def test_restores_bradley_terry_sub_competitor(self):
+        elo = EloCompetitor(initial_rating=400)
+        bradley_terry = BradleyTerryCompetitor(initial_rating=400)
+        bradley_terry.beat(BradleyTerryCompetitor(initial_rating=400))
+        expected_rating = bradley_terry.rating
+
+        restored = BlendedCompetitor.from_state(self._legacy_state(elo, bradley_terry))
+
+        self.assertEqual(
+            [type(c).__name__ for c in restored.sub_competitors], ["EloCompetitor", "BradleyTerryCompetitor"]
+        )
+        self.assertEqual(restored.sub_competitors[0].rating, 400)
+        self.assertAlmostEqual(restored.sub_competitors[1].rating, expected_rating)
+        self.assertAlmostEqual(restored.expected_score(restored), 0.5)
+
+    def test_accepts_every_registered_competitor_type(self):
+        names = [n for n in BaseCompetitor.list_competitor_types() if n != "BlendedCompetitor"]
+        self.assertIn("BradleyTerryCompetitor", names)
+
+        for name in names:
+            with self.subTest(competitor_type=name):
+                sub_competitor = self._new_competitor(name)
+                restored = BlendedCompetitor.from_state(self._legacy_state(sub_competitor))
+                self.assertEqual(len(restored.sub_competitors), 1)
+                self.assertIsInstance(restored.sub_competitors[0], type(sub_competitor))
+                self.assertAlmostEqual(restored.sub_competitors[0].rating, sub_competitor.rating)
+
+    def test_unknown_competitor_type_raises(self):
+        state = {"blend_mode": "mean", "competitors": [{"type": "NotACompetitor", "competitor_kwargs": {}}]}
+
+        with self.assertRaisesRegex(InvalidParameterException, "Unknown competitor type: NotACompetitor"):
+            BlendedCompetitor.from_state(state)


### PR DESCRIPTION
Closes #114

`BlendedCompetitor.from_state`'s legacy branch resolved sub-competitor class names through a hand-maintained `competitor_types` dict in `elote/competitors/ensemble.py`, duplicating the `BaseCompetitor` subclass registry that `__init__` already used for construction. Both lookups now call `BaseCompetitor.get_competitor_class`, and the dict is gone.

## What changed

- **`elote/competitors/ensemble.py`** — deleted `competitor_types` and the concrete-class imports it needed; both legacy lookups go through `BaseCompetitor.get_competitor_class`, which raises the same `InvalidParameterException(f"Unknown competitor type: {name}")`, so the explicit `if comp_type is None` block collapsed into the call.
- **Same file, legacy construction** — the legacy branch hardcoded `{"initial_rating": comp_kwargs.get("initial_rating", 400)}` when building each sub-competitor spec. `TrueSkillCompetitor` (which was *in* the old map) and `PythagoreanCompetitor` take no `initial_rating`, so that line raised for them regardless of the registry fix. It now forwards an initial rating only when the saved state carries one. This was needed to satisfy the "accepts every registered type" acceptance item, not incidental cleanup. Behaviour delta: a legacy sub-state with no `initial_rating` now gets its class default instead of a forced 400 — observable only in the restored competitor's exported `parameters.competitors`, since the sub-competitor object is replaced from its full state one loop later.
- **`.cursor/rules/implementing_competitors.mdc`** — "Step 5" told contributors to add their new class to `competitor_types`. That instruction is what the drift came from (five classes had accumulated), so it now states that `__init_subclass__` registers the class automatically and there is nothing to update.
- **`tests/test_BlendedCompetitor.py`** — new `TestBlendedCompetitorLegacyState` with three tests: a Bradley-Terry sub-competitor round-trips through legacy state, the legacy path accepts every name in `BaseCompetitor.list_competitor_types()` (excluding `BlendedCompetitor`), and an unknown name still raises `InvalidParameterException` with the unchanged message.

## Scope note: the drift was five classes, and one shape still can't restore

The issue reported `BradleyTerryCompetitor` missing from the map. Measured on `master` at `eacb7ee`, the registry holds 13 classes and the map held 7 — `BradleyTerryCompetitor`, `KeenerCompetitor`, `MasseyCompetitor`, `PythagoreanCompetitor` and `WholeHistoryRatingCompetitor` were all unreachable through the legacy path. All five work now.

One thing this PR deliberately does **not** fix. Legacy state nests each sub-competitor's own saved state under `competitor_kwargs`, and the loop restores it with `comp_type.from_state(comp_kwargs)`. Only `elo`, `ecf`, `dwz`, `glicko`, `glicko2`, `trueskill` and `colley` implement a `if "type" not in state` legacy branch in their own `from_state`; the five newer classes go straight to `BaseCompetitor.from_state`, which requires the modern `type`/`parameters`/`state` document. So the *flat* sub-state in the issue's Problem section still fails, with a different error:

    InvalidStateException: Failed to update sub-competitor BradleyTerryCompetitor from legacy state: State must contain a 'type' field

Making that shape work means adding legacy `from_state` branches to five competitor modules — a separate, larger change — and no released version of elote ever produced such a document, since all five classes postdate the modern format. The new tests therefore nest each class's own `export_state()` as `competitor_kwargs`, which is the shape a real saved document has. Worth noting the flat shape was never universally supported anyway: on `master`, `TrueSkillCompetitor` and `ColleyMatrixCompetitor` are both *in* the map and both fail it (unexpected `initial_rating` kwarg; missing `rating`/`wins`/`losses`/`ties`).

## Verification

Python 3.12 venv, `PYTHONDONTWRITEBYTECODE=1` throughout.

- `.venv/bin/python -m pytest -q --ignore=tests/test_examples.py` — **526 passed, 6 skipped**; base `eacb7ee` measured in the same venv is **523 passed, 6 skipped** (+3 new tests). `tests/test_examples.py` is excluded as usual (long-running, regenerates tracked PNGs); no example script references `BlendedCompetitor`.
- `ruff check .` — All checks passed. `ruff format --check` clean on both touched files.
- Registry vs. legacy path, before: map = 7 names, registry = 13; `BlendedCompetitor.from_state` on legacy state naming any of the 5 missing classes raised `Unknown competitor type`. After: all 12 non-ensemble registered classes restore, with sub-competitor type and rating preserved.

Mutation checks (each applied, confirmed against the value the interpreter actually imports, then reverted with a green re-run):

1. **Reinstate the 7-entry map for both lookups** → `test_restores_bradley_terry_sub_competitor` and `test_accepts_every_registered_competitor_type` both fail (`InvalidParameterException: Unknown competitor type: BradleyTerryCompetitor`). 7 passed / 2 failed.
2. **Restore the hardcoded `{"initial_rating": ... , 400}` spec, keeping the registry fix** → `test_accepts_every_registered_competitor_type` fails on `TrueSkillCompetitor.__init__() got an unexpected keyword argument 'initial_rating'`. 8 passed / 1 failed. So the two halves of the change are guarded separately; the all-types test is the one that carries both.

After restore: `tests/test_BlendedCompetitor.py` 9 passed.