### PR TITLE
Accept NumPy real scalars in score payloads

### DIFF
--- a/elote/competitors/base.py
+++ b/elote/competitors/base.py
@@ -1,6 +1,7 @@
 import abc
 import json
 import math
+import numbers
 import uuid
 from typing import Dict, Any, Optional, Sequence, Tuple, TypeVar, Type, ClassVar, List, cast
 
@@ -64,6 +65,8 @@ def validate_scores(scores: Optional[Sequence[float]], outcome: float) -> Option
 
     Args:
         scores (sequence of float, optional): The two scores in caller order, or ``None``.
+            Any real number is accepted -- including NumPy scalars such as ``np.int64`` and
+            ``np.float32`` -- and normalized to a built-in ``float``.
         outcome (float): The declared result from the first score's perspective --
             ``1.0`` (first competitor won), ``0.0`` (first competitor lost) or ``0.5`` (draw).
 
@@ -85,13 +88,17 @@ def validate_scores(scores: Optional[Sequence[float]], outcome: float) -> Option
 
     validated: List[float] = []
     for value in scores:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
+        # numbers.Real rather than the built-in types, so the NumPy scalars a pandas or
+        # NumPy pipeline produces are accepted here exactly as they are by the dataset
+        # score path. Booleans and complex values are still not real numbers.
+        if isinstance(value, bool) or not isinstance(value, numbers.Real):
             raise ValueError(f"scores must contain only numbers, got {value!r}")
-        if not math.isfinite(value):
+        as_float = float(value)
+        if not math.isfinite(as_float):
             raise ValueError(f"scores must be finite, got {value!r}")
-        if value < 0:
+        if as_float < 0:
             raise ValueError(f"scores must be non-negative, got {value!r}")
-        validated.append(float(value))
+        validated.append(as_float)
 
     first, second = validated
     if outcome == 1.0 and not first > second:

--- a/tests/test_score_channel.py
+++ b/tests/test_score_channel.py
@@ -10,6 +10,8 @@ import datetime
 import random
 import unittest
 
+import numpy as np
+
 from elote import (
     BradleyTerryCompetitor,
     ColleyMatrixCompetitor,
@@ -28,6 +30,7 @@ from elote import (
     benchmark_competitors,
     train_arena_with_dataset,
 )
+from elote.competitors.base import validate_scores
 
 
 def _always_true(a, b, attributes=None):
@@ -68,6 +71,12 @@ class TestScoreValidation(unittest.TestCase):
         ("too long", (3.0, 1.0, 0.0)),
         ("non numeric", (3.0, "1")),
         ("boolean", (True, False)),
+        ("numpy boolean", (np.bool_(True), np.bool_(False))),
+        ("complex", (complex(3, 0), complex(1, 0))),
+        ("numpy complex", (np.complex128(3), np.complex128(1))),
+        ("numpy nan", (np.float32("nan"), np.float32(1.0))),
+        ("numpy infinite", (np.float32("inf"), np.float32(1.0))),
+        ("numpy negative", (np.float32(3.0), np.float32(-1.0))),
         ("negative", (3.0, -1.0)),
         ("infinite", (float("inf"), 1.0)),
         ("nan", (float("nan"), 1.0)),
@@ -108,6 +117,86 @@ class TestScoreValidation(unittest.TestCase):
                 before = (a.export_state()["state"], b.export_state()["state"])
                 with self.assertRaises(ValueError):
                     a.beat(b, scores=(-1.0, -2.0))
+                self.assertEqual((a.export_state()["state"], b.export_state()["state"]), before)
+
+
+class TestNumpyScoreValidation(unittest.TestCase):
+    """Real NumPy scalars are as acceptable as the built-in numbers they stand in for.
+
+    NumPy and pandas pipelines hand out ``np.int64``/``np.float32`` rather than ``int``/
+    ``float``, and the dataset score path already accepts any non-boolean ``numbers.Real``.
+    ``np.float64`` is deliberately absent from these fixtures: it subclasses ``float``, so it
+    was accepted before this contract was widened and proves nothing.
+    """
+
+    # (label, win_scores) -- the winner's score first, as beat() requires.
+    NUMPY_SCALARS = (
+        ("numpy int64", (np.int64(3), np.int64(1))),
+        ("numpy int32", (np.int32(3), np.int32(1))),
+        ("numpy float32", (np.float32(3.5), np.float32(1.25))),
+        ("numpy float16", (np.float16(3.0), np.float16(1.0))),
+        ("mixed numpy and builtin", (np.int64(3), 1.0)),
+    )
+
+    def test_validate_scores_normalizes_to_builtin_floats(self):
+        """The accepted values come back as built-in floats, not the NumPy scalars given."""
+        for label, win_scores in self.NUMPY_SCALARS:
+            with self.subTest(payload=label):
+                first, second = validate_scores(win_scores, 1.0)
+                # `is float`, not isinstance: np.float64 subclasses float, so isinstance
+                # would pass on an implementation that skipped the conversion entirely.
+                self.assertIs(type(first), float)
+                self.assertIs(type(second), float)
+                self.assertEqual((first, second), (float(win_scores[0]), float(win_scores[1])))
+
+    def test_results_accept_numpy_scores_for_every_competitor(self):
+        """beat/lost_to/tied take outcome-consistent NumPy pairs and move real ratings."""
+        for competitor_class in COMPETITOR_CLASSES:
+            for label, win_scores in self.NUMPY_SCALARS:
+                with self.subTest(competitor=competitor_class.__name__, payload=label):
+                    high, low = win_scores
+                    draw = (low, low)
+
+                    a, b = competitor_class(), competitor_class()
+                    before = a.export_state()["state"]
+                    a.beat(b, scores=(high, low))
+                    a.lost_to(b, scores=(low, high))
+                    a.tied(b, scores=draw)
+                    self.assertNotEqual(a.export_state()["state"], before)
+
+    def test_numpy_scores_match_the_equivalent_builtin_payload(self):
+        """A NumPy pair and its float equivalent drive identical rating updates."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                numpy_a, numpy_b = competitor_class(), competitor_class()
+                float_a, float_b = competitor_class(), competitor_class()
+
+                numpy_a.beat(numpy_b, scores=(np.int64(3), np.float32(1.0)))
+                float_a.beat(float_b, scores=(3.0, 1.0))
+
+                # Glicko-1/Glicko-2 inflate RD from wall-clock elapsed time, so the two runs
+                # differ by ~1e-10 for reasons unrelated to the score payload.
+                self.assertAlmostEqual(numpy_a.rating, float_a.rating, places=6)
+                self.assertAlmostEqual(numpy_b.rating, float_b.rating, places=6)
+
+    def test_numpy_scores_that_disagree_with_the_outcome_are_rejected(self):
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                a, b = competitor_class(), competitor_class()
+                with self.assertRaises(ValueError):
+                    a.beat(b, scores=(np.int64(1), np.int64(3)))
+                with self.assertRaises(ValueError):
+                    a.lost_to(b, scores=(np.float32(3.0), np.float32(1.0)))
+                with self.assertRaises(ValueError):
+                    a.tied(b, scores=(np.int64(3), np.int64(1)))
+
+    def test_rejected_numpy_scores_leave_both_competitors_untouched(self):
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                a, b = competitor_class(), competitor_class()
+                before = (a.export_state()["state"], b.export_state()["state"])
+                with self.assertRaises(ValueError):
+                    a.beat(b, scores=(np.float32("nan"), np.float32(1.0)))
                 self.assertEqual((a.export_state()["state"], b.export_state()["state"]), before)
 
 


### PR DESCRIPTION
Closes #161

## What changed

`validate_scores` in `elote/competitors/base.py` gated each score on `isinstance(value, (int, float))`, so `np.int64(3)` and `np.float32(3.0)` — the ordinary output of a NumPy or pandas pipeline — were rejected with `ValueError: scores must contain only numbers` before any competitor update. The dataset score path (`_scores_from_attributes` in `elote/datasets/utils.py`) already uses the broader non-boolean `numbers.Real` contract, so the public `scores=` API was narrower than the library's own internal one.

`validate_scores` now uses that same contract: a non-boolean `numbers.Real` is accepted and converted to a built-in `float`, and the finiteness, non-negativity and outcome-consistency checks then run on the converted value exactly as before. Booleans (built-in and `np.bool_`), complex values, negative, non-finite, malformed and outcome-inconsistent payloads all stay rejected.

## Tests

`tests/test_score_channel.py` gains `TestNumpyScoreValidation` (5 tests, run across all 12 competitor classes) covering normalization to built-in floats, `beat`/`lost_to`/`tied` accepting NumPy pairs and actually moving state, NumPy and built-in payloads producing identical updates, and rejection of outcome-inconsistent NumPy pairs leaving both sides untouched. The existing `BAD_PAYLOADS` table gains `np.bool_`, `complex`, `np.complex128`, and NumPy NaN/inf/negative rows.

Two notes on fixture choice:

- `np.float64` is deliberately **not** a fixture: it subclasses `float`, so it was accepted before this change and would prove nothing. The fixtures that actually change behaviour are `np.int64`, `np.int32`, `np.float32` and `np.float16`.
- The normalization assertion uses `assertIs(type(first), float)` rather than `isinstance` — for the same reason, `isinstance(np.float64(3.0), float)` is `True`, so an `isinstance` check would pass on an implementation that skipped the conversion.

## Verification

All commands run from a `uv venv --python 3.12` + `uv sync --extra dev` environment, driven as `env -u VIRTUAL_ENV .venv/bin/python -m ...`.

| Check | Result |
| --- | --- |
| `pytest -q tests/test_score_channel.py` | 33 passed (28 on master) |
| `pytest -q --ignore=tests/test_examples.py` | **531 passed, 6 skipped** (baseline on master at `fc33143`: 526 passed, 6 skipped) |
| `ruff check .` | All checks passed |
| `ruff format --check` on both changed files | already formatted |
| `mypy elote` | Success: no issues found in 29 source files |

### The new tests are not vacuous

Three mutations of `validate_scores`, each with `__pycache__` cleared before and after so no stale bytecode could mask the result, and the restore re-verified by importing the value the interpreter actually loads:

1. **Revert the widening** (`numbers.Real` → `(int, float)`) — 3 tests fail: `test_validate_scores_normalizes_to_builtin_floats`, `test_results_accept_numpy_scores_for_every_competitor`, `test_numpy_scores_match_the_equivalent_builtin_payload`.
2. **Keep the widening but drop the `float()` conversion** (append the raw value) — exactly 1 test fails, `test_validate_scores_normalizes_to_builtin_floats`. This is the mutation that acceptance item 2 exists for, and it is the only test that catches it; the other four pass on it.
3. **Over-widen to `numbers.Number`** (the plausible wrong fix, which would newly admit complex values) — `test_malformed_scores_rejected_for_every_competitor` fails on the new `complex` rows.

To be explicit about which assertions carry behaviour and which are documentation: `test_numpy_scores_that_disagree_with_the_outcome_are_rejected` and `test_rejected_numpy_scores_leave_both_competitors_untouched` pass under mutation 1 as well (both sides raise `ValueError`, just for different reasons), so they document the contract for NumPy inputs rather than guarding the widening itself. The `np.bool_` and `np.complex128` bad-payload rows are likewise already rejected on master — they guard against future over-widening (mutation 3), not against the current bug.