### PR TITLE
[autopilot] release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+v1.3.3
+======
+
+Bug fixes
+
+ * Legacy ``BlendedCompetitor`` state now restores sub-competitors through the shared
+   competitor registry. This adds support for every registered rating system, including
+   systems such as TrueSkill and Pythagorean that do not accept an ``initial_rating``
+   constructor argument. Previously, restoring those states could reject a valid competitor
+   type or fail during construction.
+
 v1.3.2
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "elote"
-version = "1.3.2"
+version = "1.3.3"
 description = "Python module for rating bouts (like with Elo Rating)"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Release notes

### Bug fixes

- Legacy `BlendedCompetitor` state now restores sub-competitors through the shared competitor registry. This supports every registered rating system, including systems such as TrueSkill and Pythagorean that do not accept an `initial_rating` constructor argument. Previously, restoring those states could reject a valid competitor type or fail during construction.

## Why now

This is a backward-compatible serialization correctness fix. The release policy calls for a patch release for user-visible correctness and serialization fixes without holding them for unrelated changes.

## Verification

- `python -m pytest -q --ignore=tests/test_examples.py` — 526 passed, 6 skipped
- `python -m ruff check .` — passed
- `python -m mypy elote` — passed
- Sphinx HTML build using `docs/requirements.txt` — passed with the existing 531-warning baseline
- `python -m build --sdist` — passed
- Inspected `elote-1.3.3.tar.gz`: package metadata reports 1.3.3 and the archive contains `pyproject.toml` and the `elote` package

## Downstream

- `wdm0006/collaborank`: dependency range in `pyproject.toml` (`elote>=1.2.1,<2`) and resolved artifact in `uv.lock`. No update is required for this serialization-only, backward-compatible fix; review after release remains optional because its runtime uses `LambdaArena`, which is unchanged.

## Publishing

The **PyPI Packaging** workflow (`.github/workflows/pypi-publish.yml`) runs when the GitHub Release is created. It builds an sdist with `python -m build --sdist` and publishes it to PyPI through Trusted Publishing. A pushed tag alone does not trigger publishing.

Post-merge steps:

```bash
git checkout master && git pull
git tag -a v1.3.3 -m "v1.3.3" && git push origin v1.3.3
gh release create v1.3.3 --title "v1.3.3" --notes "Fix legacy BlendedCompetitor state restoration by resolving all sub-competitor types through the shared registry, including rating systems without an initial_rating constructor argument."
```
