### PR TITLE
Add a uniform rating-period operation

### DIFF
--- a/docs/source/arenas.rst
+++ b/docs/source/arenas.rst
@@ -7,6 +7,23 @@ type of arena implemented, LambdaArenas
 Lambda Arena
 ------------
 
+Rating periods
+~~~~~~~~~~~~~~
+
+A rating period is a batch of results that share one pre-period rating state. Use
+:meth:`~elote.LambdaArena.rating_period` when every prediction in the batch should
+be made before any result in that batch changes a rating. This differs from calling
+:meth:`~elote.LambdaArena.matchup` repeatedly, where each result immediately informs
+the next prediction.
+
+Each row is ``(competitor_a, competitor_b, outcome, scores)``. The outcome is
+``1.0``, ``0.0``, or ``0.5`` from the first competitor's perspective, and scores
+may be ``None``. All currently shipped rating systems use
+:meth:`~elote.competitors.base.BaseCompetitor.apply_rating_period`'s sequential
+default, so their final ratings match a stream of the same pairwise updates. A
+period-native system can override that operation to update its population
+simultaneously while keeping the pairwise API intact.
+
 .. autoclass:: elote.arenas.lambda_arena.LambdaArena
     :members:
 
@@ -19,5 +36,4 @@ Helpers
 
 .. autoclass:: elote.arenas.base.Bout
     :members:
-
 

--- a/elote/__init__.py
+++ b/elote/__init__.py
@@ -43,6 +43,7 @@ Analysis and Benchmarking:
 """
 
 # Core competitors - always available
+from elote.competitors.base import BaseCompetitor
 from elote.competitors.elo import EloCompetitor
 from elote.competitors.glicko import GlickoCompetitor
 from elote.competitors.glicko2 import Glicko2Competitor
@@ -89,6 +90,7 @@ from typing import Any, List, Dict
 # Base __all__ list with always-available exports
 __all__ = [
     # Competitors
+    "BaseCompetitor",
     "EloCompetitor",
     "GlickoCompetitor",
     "Glicko2Competitor",

--- a/elote/arenas/lambda_arena.py
+++ b/elote/arenas/lambda_arena.py
@@ -188,6 +188,51 @@ class LambdaArena(BaseArena):
                 self.competitors[b].beat(self.competitors[a], scores=reversed_scores)
             self.history.add_bout(Bout(a, b, predicted_outcome, outcome="loss", attributes=attributes))
 
+    def rating_period(
+        self,
+        matchups: Sequence[Tuple[Any, Any, float, Optional[Sequence[float]]]],
+        *,
+        period_end: Optional[datetime.datetime] = None,
+    ) -> None:
+        """Process a batch of results against one shared pre-period state.
+
+        Every row is validated before the arena is changed. Predictions for all rows
+        are then captured before the batch is applied, so an earlier result in the
+        period cannot inform a later prediction from the same period.
+
+        Args:
+            matchups: ``(competitor_a, competitor_b, outcome, scores)`` tuples. Outcomes
+                are ``1.0``, ``0.0``, or ``0.5`` from A's perspective. Scores are
+                optional and use ``(a_score, b_score)`` caller order.
+
+            period_end: The shared activity time for time-aware competitors.
+
+        Raises:
+            ValueError: If any outcome or score payload is invalid. Validation happens
+                before competitors or bouts are added.
+        """
+        validated_matchups: List[Tuple[Any, Any, float, Optional[Tuple[float, float]]]] = []
+        for a, b, outcome, scores in matchups:
+            self._validate_outcome(outcome)
+            validated_scores = BaseCompetitor._validate_scores(scores, outcome)
+            validated_matchups.append((a, b, outcome, validated_scores))
+
+        for a, b, _, _ in validated_matchups:
+            if a not in self.competitors:
+                self.competitors[a] = self.base_competitor(**self.base_competitor_kwargs)
+            if b not in self.competitors:
+                self.competitors[b] = self.base_competitor(**self.base_competitor_kwargs)
+
+        predictions = [self.expected_score(a, b) for a, b, _, _ in validated_matchups]
+        results = [
+            (self.competitors[a], self.competitors[b], outcome, scores)
+            for a, b, outcome, scores in validated_matchups
+        ]
+        self.base_competitor.apply_rating_period(results, period_end=period_end)
+
+        for (a, b, outcome, _), predicted_outcome in zip(validated_matchups, predictions, strict=True):
+            self.history.add_bout(Bout(a, b, predicted_outcome, outcome=outcome))
+
     def expected_score(self, a: Any, b: Any) -> float:
         """Calculate the expected score for a matchup between two competitors.
 

--- a/elote/competitors/base.py
+++ b/elote/competitors/base.py
@@ -276,6 +276,54 @@ class BaseCompetitor(abc.ABC):
         """
         pass
 
+    @classmethod
+    def apply_rating_period(
+        cls,
+        results: Sequence[Tuple["BaseCompetitor", "BaseCompetitor", float, Optional[Sequence[float]]]],
+        *,
+        period_end: Optional[Any] = None,
+    ) -> None:
+        """Apply results that share one rating period.
+
+        The default implementation replays results in order through the pairwise
+        methods. Rating systems whose published update is period-native can override
+        this method to update the population simultaneously without changing the
+        existing pairwise API.
+
+        Args:
+            results: ``(competitor_a, competitor_b, outcome, scores)`` tuples. Outcomes
+                use ``1.0`` for an A win, ``0.0`` for a B win, and ``0.5`` for a draw;
+                scores follow the same optional caller-order contract as :meth:`beat`.
+
+            period_end: The shared activity time for time-aware competitors.
+
+        Raises:
+            ValueError: If an outcome is not ``1.0``, ``0.0``, or ``0.5``, or if a
+                score payload is invalid or inconsistent with its outcome.
+        """
+        for competitor_a, competitor_b, outcome, scores in results:
+            if outcome not in (1.0, 0.0, 0.5):
+                raise ValueError(f"outcome must be one of 1.0, 0.0 or 0.5, got {outcome!r}")
+
+            supports_time = hasattr(competitor_a, "_last_activity")
+            if outcome == 1.0:
+                if supports_time:
+                    competitor_a.beat(competitor_b, match_time=period_end, scores=scores)  # type: ignore[call-arg]
+                else:
+                    competitor_a.beat(competitor_b, scores=scores)
+            elif outcome == 0.0:
+                reversed_scores = None if scores is None else (scores[1], scores[0])
+                if supports_time:
+                    competitor_b.beat(  # type: ignore[call-arg]
+                        competitor_a, match_time=period_end, scores=reversed_scores
+                    )
+                else:
+                    competitor_b.beat(competitor_a, scores=reversed_scores)
+            elif supports_time:
+                competitor_a.tied(competitor_b, match_time=period_end, scores=scores)  # type: ignore[call-arg]
+            else:
+                competitor_a.tied(competitor_b, scores=scores)
+
     def export_state(self) -> Dict[str, Any]:
         """Export the current state of this competitor for serialization.
 

--- a/tests/test_rating_period.py
+++ b/tests/test_rating_period.py
@@ -1,0 +1,131 @@
+import datetime
+from unittest.mock import patch
+
+import pytest
+
+from elote import (
+    BradleyTerryCompetitor,
+    ColleyMatrixCompetitor,
+    DWZCompetitor,
+    ECFCompetitor,
+    EloCompetitor,
+    Glicko2Competitor,
+    GlickoCompetitor,
+    KeenerCompetitor,
+    LambdaArena,
+    MasseyCompetitor,
+    PythagoreanCompetitor,
+    TrueSkillCompetitor,
+    WholeHistoryRatingCompetitor,
+)
+
+
+COMPETITOR_CLASSES = (
+    EloCompetitor,
+    GlickoCompetitor,
+    Glicko2Competitor,
+    TrueSkillCompetitor,
+    ECFCompetitor,
+    DWZCompetitor,
+    ColleyMatrixCompetitor,
+    MasseyCompetitor,
+    KeenerCompetitor,
+    PythagoreanCompetitor,
+    BradleyTerryCompetitor,
+    WholeHistoryRatingCompetitor,
+)
+PERIOD_END = datetime.datetime(2026, 1, 15, tzinfo=datetime.timezone.utc)
+
+
+def _populations(competitor_class):
+    return ({name: competitor_class() for name in "ABC"}, {name: competitor_class() for name in "ABC"})
+
+
+def _apply_pairwise(results):
+    for competitor_a, competitor_b, outcome, scores in results:
+        supports_time = hasattr(competitor_a, "_last_activity")
+        kwargs = {"scores": scores}
+        if supports_time:
+            kwargs["match_time"] = PERIOD_END
+        if outcome == 1.0:
+            competitor_a.beat(competitor_b, **kwargs)
+        elif outcome == 0.0:
+            reversed_scores = None if scores is None else (scores[1], scores[0])
+            competitor_b.beat(competitor_a, **{**kwargs, "scores": reversed_scores})
+        else:
+            competitor_a.tied(competitor_b, **kwargs)
+
+
+@pytest.mark.parametrize("competitor_class", COMPETITOR_CLASSES)
+def test_default_rating_period_matches_pairwise_replay(competitor_class):
+    period_population, pairwise_population = _populations(competitor_class)
+    rows = (("A", "B", 1.0), ("B", "C", 0.5), ("A", "C", 0.0), ("A", "B", 1.0))
+    period_results = [(period_population[a], period_population[b], outcome, None) for a, b, outcome in rows]
+    pairwise_results = [(pairwise_population[a], pairwise_population[b], outcome, None) for a, b, outcome in rows]
+
+    competitor_class.apply_rating_period(period_results, period_end=PERIOD_END)
+    _apply_pairwise(pairwise_results)
+
+    for name in period_population:
+        if competitor_class is WholeHistoryRatingCompetitor:
+            # WHR's lazy fit traverses object-hash-ordered graphs, so independently
+            # built populations can differ slightly from floating-point summation order.
+            assert period_population[name].rating == pytest.approx(pairwise_population[name].rating, abs=1e-4)
+        else:
+            assert period_population[name].rating == pairwise_population[name].rating
+
+
+def test_rating_period_records_pre_period_predictions():
+    arena = LambdaArena(lambda a, b: True)
+    initial_prediction = EloCompetitor().expected_score(EloCompetitor())
+
+    arena.rating_period([("A", "B", 1.0, None), ("A", "B", 1.0, None)])
+
+    assert [bout.predicted_outcome for bout in arena.history.bouts] == [initial_prediction, initial_prediction]
+    streaming = LambdaArena(lambda a, b: True)
+    streaming.matchup("A", "B", outcome=1.0)
+    assert streaming.expected_score("A", "B") != initial_prediction
+
+
+def test_rating_period_applies_the_batch_once():
+    arena = LambdaArena(lambda a, b: True)
+    rows = [("A", "B", 1.0, None), ("B", "C", 0.5, None)]
+
+    with patch.object(EloCompetitor, "apply_rating_period", wraps=EloCompetitor.apply_rating_period) as apply:
+        arena.rating_period(rows, period_end=PERIOD_END)
+
+    apply.assert_called_once()
+    assert len(apply.call_args.args[0]) == len(rows)
+    assert apply.call_args.kwargs == {"period_end": PERIOD_END}
+
+
+@pytest.mark.parametrize(
+    "matchups, message",
+    [
+        ([("A", "B", 1.0, None), ("C", "D", 0.25, None)], "outcome must be one of"),
+        ([("A", "B", 1.0, None), ("C", "D", 1.0, (0, 1))], "do not describe a win"),
+    ],
+)
+def test_invalid_rating_period_leaves_arena_unchanged(matchups, message):
+    arena = LambdaArena(lambda a, b: True)
+
+    with pytest.raises(ValueError, match=message):
+        arena.rating_period(matchups)
+
+    assert arena.competitors == {}
+    assert arena.history.bouts == []
+
+
+@pytest.mark.parametrize("competitor_class", [EloCompetitor, ColleyMatrixCompetitor])
+def test_arena_rating_period_matches_streaming_final_ratings(competitor_class):
+    rows = [("A", "B", 1.0, None), ("B", "C", 0.5, None), ("A", "C", 0.0, None)]
+    period_arena = LambdaArena(lambda a, b: True, base_competitor=competitor_class)
+    streaming_arena = LambdaArena(lambda a, b: True, base_competitor=competitor_class)
+
+    period_arena.rating_period(rows)
+    for a, b, outcome, scores in rows:
+        streaming_arena.matchup(a, b, outcome=outcome, scores=scores)
+
+    assert {name: competitor.rating for name, competitor in period_arena.competitors.items()} == {
+        name: competitor.rating for name, competitor in streaming_arena.competitors.items()
+    }


### PR DESCRIPTION
Closes #163

## Summary

- add `BaseCompetitor.apply_rating_period` as a concrete classmethod whose default replays results through the existing pairwise methods
- add `LambdaArena.rating_period` with whole-batch validation, pre-period predictions, one batch application, and one recorded `Bout` per result
- document rating periods and export `BaseCompetitor` from the package facade
- cover replay equivalence across all 12 concrete systems, atomic validation, prediction timing, single-call delegation, and arena equivalence for incremental and global-fit systems

No shipped rating system's numbers change. Every current system inherits the sequential default; `test_default_rating_period_matches_pairwise_replay` proves exact final-rating equality for 11 systems and uses the documented tolerance only for Whole-History Rating's object-hash-ordered lazy fit.

## Verification

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q tests` — 550 passed, 6 skipped
- `.venv/bin/ruff check .` — passed
- `cd docs && env -u VIRTUAL_ENV ../.venv/bin/python -m sphinx -b html source /tmp/elote-docs-163` — passed with 531 warnings, matching the existing warning baseline
- `git diff --check` — passed