### PR TITLE
Reject inert walk-forward tuning parameters

### DIFF
--- a/elote/evaluation.py
+++ b/elote/evaluation.py
@@ -24,7 +24,7 @@ from itertools import product
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Type
 
 from elote.arenas.lambda_arena import LambdaArena
-from elote.competitors.base import BaseCompetitor
+from elote.competitors.base import BaseCompetitor, InvalidParameterException
 from elote.datasets.utils import train_arena_with_dataset
 from elote.logging import logger
 
@@ -34,6 +34,25 @@ __all__ = ["WalkForwardReport", "TuningResult", "group_by_period", "walk_forward
 Row = Tuple[Any, Any, float, Optional[datetime], Optional[Dict[str, Any]]]
 
 _PROBABILITY_EPS = 1e-12
+
+
+def _validate_competitor_params(competitor_class: Type[BaseCompetitor], names: Iterable[str]) -> None:
+    for name in names:
+        class_variable = f"_{name}"
+        if hasattr(competitor_class, class_variable):
+            continue
+        default_name = f"default_{name}"
+        if hasattr(competitor_class, f"_{default_name}"):
+            route = (
+                f"use {default_name!r} to tune its class-level default; "
+                f"fixed constructor arguments such as {name!r} go in base_competitor_kwargs"
+            )
+        else:
+            route = f"constructor arguments such as {name!r} go in base_competitor_kwargs"
+        raise InvalidParameterException(
+            f"{competitor_class.__name__} has no class variable {class_variable!r}; "
+            f"{route}, not competitor_params"
+        )
 
 
 @dataclass(frozen=True)
@@ -128,8 +147,10 @@ def walk_forward(
     Args:
         competitor_class: The rating system to evaluate.
         periods: Ordered periods of dataset rows, as produced by :func:`group_by_period`.
-        competitor_params: Class variables to set for the duration of the run, without the
-            leading underscore. ``{"w2": 100.0}`` sets ``_w2``.
+        competitor_params: Existing class-level knobs to set for the duration of the run,
+            without the leading underscore. ``{"default_w2": 100.0}`` sets
+            ``_default_w2``. Constructor arguments instead belong in
+            ``base_competitor_kwargs``.
         base_competitor_kwargs: Constructor keyword arguments for every competitor.
         comparison_function: Arena comparison function. Defaults to one that reports the
             recorded outcome, which is what a dataset row already carries.
@@ -149,6 +170,8 @@ def walk_forward(
     if periods and warmup >= len(periods):
         raise ValueError(f"warmup ({warmup}) leaves no periods to score (have {len(periods)})")
 
+    _validate_competitor_params(competitor_class, (competitor_params or {}).keys())
+
     comparison = comparison_function if comparison_function is not None else (lambda a, b, attributes=None: True)
     arena = LambdaArena(
         comparison,
@@ -157,7 +180,7 @@ def walk_forward(
     )
 
     overrides = {f"_{name}": value for name, value in (competitor_params or {}).items()}
-    originals = {name: getattr(competitor_class, name) for name in overrides if hasattr(competitor_class, name)}
+    originals = {name: getattr(competitor_class, name) for name in overrides}
 
     predictions = skipped = draws = 0
     log_loss_total = brier_total = 0.0
@@ -200,9 +223,6 @@ def walk_forward(
     finally:
         for name, value in originals.items():
             setattr(competitor_class, name, value)
-        for name in overrides:
-            if name not in originals:
-                delattr(competitor_class, name)
 
     if not predictions:
         logger.warning("Walk-forward produced no scored predictions (skipped %d, draws %d).", skipped, draws)
@@ -251,6 +271,8 @@ def tune(
         raise ValueError(f"unknown metric {metric!r}; expected 'log_loss', 'brier' or 'accuracy'")
     if not param_grid:
         raise ValueError("param_grid must not be empty")
+
+    _validate_competitor_params(competitor_class, param_grid)
 
     names = sorted(param_grid)
     results: List[TuningResult] = []

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -3,14 +3,17 @@
 import datetime
 import math
 import unittest
+from unittest.mock import patch
 
 from elote import (
     EloCompetitor,
     PythagoreanCompetitor,
+    WholeHistoryRatingCompetitor,
     group_by_period,
     tune,
     walk_forward,
 )
+from elote.competitors.base import InvalidParameterException
 
 
 def _row(a, b, outcome, when, scores=None):
@@ -117,6 +120,29 @@ class TestWalkForward(unittest.TestCase):
         walk_forward(PythagoreanCompetitor, _season(), warmup=1, competitor_params={"exponent": 9.0})
         self.assertEqual(PythagoreanCompetitor._exponent, before)
 
+    def test_valid_class_parameter_changes_metrics(self):
+        low = walk_forward(EloCompetitor, _season(), warmup=1, competitor_params={"k_factor": 8})
+        high = walk_forward(EloCompetitor, _season(), warmup=1, competitor_params={"k_factor": 64})
+        self.assertNotEqual(low.log_loss, high.log_loss)
+
+    def test_rejects_constructor_parameter_with_grid_searchable_default(self):
+        with self.assertRaisesRegex(InvalidParameterException, "w2.*default_w2.*base_competitor_kwargs"):
+            walk_forward(
+                WholeHistoryRatingCompetitor,
+                _season(),
+                warmup=1,
+                competitor_params={"w2": 100.0},
+            )
+
+    def test_rejects_constructor_parameter_without_class_default(self):
+        with self.assertRaisesRegex(InvalidParameterException, "initial_rating.*base_competitor_kwargs"):
+            walk_forward(EloCompetitor, _season(), warmup=1, competitor_params={"initial_rating": 1500})
+
+    def test_rejects_typo_before_training(self):
+        periods = [[("A", "B")]]
+        with self.assertRaisesRegex(InvalidParameterException, "kfactor"):
+            walk_forward(EloCompetitor, periods, competitor_params={"kfactor": 32})
+
     def test_rejects_a_warmup_that_leaves_nothing_to_score(self):
         periods = _season(weeks=2)
         with self.assertRaises(ValueError):
@@ -163,6 +189,22 @@ class TestTune(unittest.TestCase):
             tune(EloCompetitor, {"k_factor": [16]}, _season(), metric="nonsense")
         with self.assertRaises(ValueError):
             tune(EloCompetitor, {}, _season())
+
+    def test_rejects_bad_grid_before_running_any_point(self):
+        with patch("elote.evaluation.walk_forward") as mocked_walk_forward:
+            with self.assertRaisesRegex(InvalidParameterException, "kfactor"):
+                tune(EloCompetitor, {"kfactor": [8, 16, 32]}, _season())
+        mocked_walk_forward.assert_not_called()
+
+    def test_whole_history_class_default_changes_log_loss(self):
+        results = tune(
+            WholeHistoryRatingCompetitor,
+            {"default_w2": [1.0, 5000.0]},
+            _season(weeks=8, teams=("A", "B", "C", "D", "E", "F", "G", "H")),
+            warmup=1,
+        )
+        losses = {round(result.report.log_loss, 10) for result in results}
+        self.assertEqual(len(losses), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #162

## Summary

- validate `competitor_params` against real class-level knobs before arena construction
- suggest `default_<name>` when a constructor parameter has a grid-searchable class default, while retaining the fixed `base_competitor_kwargs` route
- validate `tune` grid names once before running any grid point
- correct and clarify the walk-forward parameter documentation
- add value-based coverage for Elo, Pythagorean, and Whole-History Rating parameter effects

## Verification

- `env -u VIRTUAL_ENV uv run --extra dev pytest -q tests` — 538 passed, 6 skipped
- `env -u VIRTUAL_ENV uv run --extra dev ruff check .` — passed
- `PYTHONDONTWRITEBYTECODE=1 env -u VIRTUAL_ENV .venv/bin/python -m pytest -q tests/test_evaluation.py` — 19 passed after restoring the mutation

## Mutation check

Temporarily disabled the new parameter-name guard and verified all four unknown-parameter regression tests failed: the WHR `w2` case, Elo `initial_rating`, the `kfactor` typo, and eager `tune` grid validation. Restored the guard and reran the focused suite successfully.
