### PR TITLE
docs: add rating-system decision guide + Elo/Glicko/TrueSkill comparison

### DIFF
--- a/docs/source/choose_a_rating_system.rst
+++ b/docs/source/choose_a_rating_system.rst
@@ -1,0 +1,631 @@
+.. meta::
+   :description: Route from problem characteristics — uncertainty, draws, score margins, online updates, global fits, persistence — to a shortlist of rating systems, then measure them on your own data.
+
+How to choose a rating system
+==============================
+
+.. note::
+
+   The measured tables and code output below come from a snapshot verified on
+   2026-08-09 against ten of Elote's rating systems. The library has since
+   added two more concrete systems, :doc:`Pythagorean <rating_systems/pythagorean>`
+   and :doc:`Whole-History Rating <rating_systems/whr>`, which are not covered
+   by this comparison. The runnable examples were re-checked against a current
+   install and produce the same qualitative results; a handful of measured
+   figures (noted inline) differ from this snapshot in later decimal places
+   because the library has changed since. Treat every number here as a
+   demonstration of the method, and use "Run it on your own data" below to get
+   figures for your own history and current install.
+
+**Route by what your problem looks like, not by which algorithm is famous.** If
+you need a per-competitor confidence value, three of the ten systems here give
+you one. If your results carry real scores, two of them read the margin. If your
+ranking must not depend on the order games were played in, four of them fit the
+whole result set at once. Everything else is a preference until you measure it —
+and because every system in Elote answers the same four calls, measuring it on
+your own history is a loop over a dictionary, not a rewrite.
+
+No system on this page is the best one. The measured ordering changes with the
+data: on three generated scenarios run through the same split, no system won all
+three, and on one of them the system that ranked first on accuracy ranked
+seventh of ten on Brier score.
+
+Start here
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 25
+
+   * - If your problem looks like this
+     - Start with
+     - Then read
+   * - Two competitors, a win or a loss, results arriving continuously
+     - Elo
+     - :doc:`Elo <rating_systems/elo>`
+   * - The same, but you need to know how sure the rating is
+     - Glicko-1 or Glicko-2
+     - :doc:`Elo vs Glicko vs TrueSkill <rating_systems/elo_vs_glicko_vs_trueskill>`
+   * - Competitors appear, play a handful of games, and go quiet
+     - Glicko-2
+     - :doc:`Glicko-2 <rating_systems/glicko2>`
+   * - Teams, or more than two sides per result
+     - TrueSkill
+     - :doc:`TrueSkill <rating_systems/trueskill>`
+   * - Draws are common and carry information
+     - Glicko-1, Glicko-2, or TrueSkill
+     - `Draws`_
+   * - Results carry real scores and the margin matters
+     - Massey or Keener
+     - `Score margins`_
+   * - A fixed season of results, ranked once, order must not matter
+     - Colley, Massey, Keener, or Bradley-Terry
+     - `Incremental updates or a global fit`_
+   * - You want predicted point spreads, not just probabilities
+     - Massey
+     - :doc:`Massey <rating_systems/massey>`
+   * - A national chess federation's published formula
+     - ECF or DWZ
+     - :doc:`ECF <rating_systems/ecf>`, :doc:`DWZ <rating_systems/dwz>`
+   * - You genuinely do not know
+     - Any two rows above, then measure
+     - `Run it on your own data`_
+
+The ten systems, by decision axis
+----------------------------------
+
+Every concrete system Elote exported at the time this page was measured.
+``Uncertainty`` means the object publishes a per-competitor spread you can
+read. ``Reads score margins`` means supplying a score changes the rating; the
+systems marked no accept the score channel and ignore it. ``Keeps your prior``
+means ``initial_rating`` still affects predictions after results exist.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 14 14 16 14 16 12
+
+   * - System
+     - Update model
+     - Uncertainty
+     - Reads score margins
+     - Keeps your prior
+     - Rating scale
+     - Default start
+   * - Elo
+     - Incremental
+     - no
+     - no
+     - yes
+     - Chess-like points
+     - 400
+   * - Glicko-1
+     - Incremental
+     - ``rd``
+     - no
+     - yes
+     - Chess-like points
+     - 1500
+   * - Glicko-2
+     - Incremental
+     - ``rd``, ``volatility``
+     - no
+     - yes
+     - Chess-like points
+     - 1500
+   * - TrueSkill
+     - Incremental
+     - ``sigma``
+     - no
+     - yes
+     - ``mu`` / ``sigma``
+     - ``mu`` 25, ``sigma`` 8.333
+   * - ECF
+     - Incremental
+     - no
+     - no
+     - yes
+     - ECF grading points
+     - 100
+   * - DWZ
+     - Incremental
+     - no
+     - no
+     - yes
+     - Chess-like points
+     - 400
+   * - Colley Matrix
+     - Global fit
+     - no
+     - no
+     - no
+     - ``[0, 1]``, sums to n/2
+     - 0.5
+   * - Massey
+     - Global fit
+     - no
+     - **yes**
+     - no
+     - Zero-mean margin
+     - 0.0
+   * - Keener
+     - Global fit
+     - no
+     - **yes**
+     - no
+     - Positive, mean 1.0
+     - 1.0
+   * - Bradley-Terry
+     - Global fit
+     - no
+     - no
+     - no
+     - Elo-compatible points
+     - 1500
+
+``BlendedCompetitor`` is a weighted ensemble over any of the above rather than
+a rating system in its own right, so it has no row: its behaviour on every
+axis is whatever its components' behaviour is. See
+:doc:`Ensemble <rating_systems/ensemble>`. ``PythagoreanCompetitor`` and
+``WholeHistoryRatingCompetitor`` are newer additions not covered by this
+comparison; see their own pages for their axes.
+
+Two consequences of that table are worth stating before you read further,
+because both surprise people:
+
+- The default starting rating is **not** the same across systems — it ranges
+  from 100 to 1500. If you compare systems without passing ``initial_rating``,
+  part of what you measure is the difference between those defaults. Set it
+  explicitly.
+- For the four global-fit systems, ``initial_rating`` is a placeholder, not a
+  prior. Started at 1600 against 1400, Bradley-Terry predicts 0.7597 for the
+  favourite; after a single drawn game it predicts exactly 0.5000, with both
+  ratings back at 1500. The fit sees results, not your beliefs about them.
+
+One workflow, ten systems
+---------------------------
+
+The reason a comparison is cheap here is that the workflow does not change.
+Feed results to an arena; read a leaderboard and an expected score out of it.
+Swapping the rating system is one constructor argument:
+
+.. code-block:: python
+
+    from elote import EloCompetitor, GlickoCompetitor, LambdaArena
+
+    # Your own results, always from a's point of view:
+    # 1.0 means a won, 0.0 means b won, 0.5 means a draw.
+    results = [
+        ("ann", "bob", 1.0),
+        ("bob", "cid", 1.0),
+        ("ann", "cid", 0.5),
+        ("dee", "ann", 1.0),
+        ("dee", "bob", 1.0),
+    ]
+
+
+    def rate(system, **kwargs):
+        arena = LambdaArena(lambda a, b: None, base_competitor=system, base_competitor_kwargs=kwargs)
+        for a, b, outcome in results:
+            arena.matchup(a, b, outcome=outcome)
+        return arena
+
+
+    elo = rate(EloCompetitor, initial_rating=1500)
+    for entry in elo.leaderboard():
+        print(f"{entry['competitor']:>4} {entry['rating']:8.1f}")
+    print(f"Elo    P(ann beats bob) = {elo.expected_score('ann', 'bob'):.3f}")
+
+    # Changing rating system is one argument. Nothing else about the loop changes.
+    glicko = rate(GlickoCompetitor, initial_rating=1500)
+    print(f"Glicko P(ann beats bob) = {glicko.expected_score('ann', 'bob'):.3f}")
+
+.. code-block:: text
+
+     dee   1531.9
+     ann   1497.8
+     bob   1485.5
+     cid   1484.8
+    Elo    P(ann beats bob) = 0.518
+    Glicko P(ann beats bob) = 0.508
+
+The ``lambda`` is the arena's fallback for deciding a result it was not given.
+It is never called here, because every call passes an explicit ``outcome``.
+See :doc:`Arenas <arenas>` for the form where the arena decides outcomes
+itself.
+
+Uncertainty
+-----------
+
+Three systems publish a per-competitor spread: Glicko-1 as ``rd``, Glicko-2 as
+``rd`` plus ``volatility``, and TrueSkill as ``sigma``. The other seven give
+you a number with no attached notion of how much evidence is behind it.
+
+.. code-block:: python
+
+    from elote import EloCompetitor, GlickoCompetitor, TrueSkillCompetitor
+
+
+    def after(system, games, **kwargs):
+        a, b = system(**kwargs), system(**kwargs)
+        for _ in range(games):
+            a.beat(b)
+        return a
+
+
+    print(f"{'games':>6}{'elo rating':>12}{'glicko rd':>12}{'trueskill sigma':>18}")
+    for games in (0, 1, 5, 20):
+        elo = after(EloCompetitor, games, initial_rating=1500)
+        glicko = after(GlickoCompetitor, games, initial_rating=1500)
+        trueskill = after(TrueSkillCompetitor, games)
+        print(f"{games:>6}{elo.rating:>12.1f}{glicko.rd:>12.2f}{trueskill.sigma:>18.3f}")
+
+.. code-block:: text
+
+     games  elo rating   glicko rd   trueskill sigma
+         0      1500.0      350.00             8.333
+         1      1516.0      290.23             7.171
+         5      1566.8      223.26             5.585
+        20      1665.4      177.98             4.413
+
+Choose one of these three when a downstream decision depends on confidence:
+matchmaking that should not pair a settled competitor against an unknown one,
+a leaderboard that should hold back a new entrant, or any place you would
+otherwise hand-roll a "minimum games played" rule.
+
+One caveat specific to this library rather than to the algorithms. Glicko-1
+and Glicko-2 also inflate ``rd`` for competitors who have not played
+recently, but the arena rejects a match timestamp earlier than the
+competitor's creation time, so that decay cannot be exercised through an
+arena on historical data. On a back-test it is inert.
+
+Draws
+-----
+
+All ten systems accept a drawn result. They disagree sharply about what one
+means. Starting a favourite at 1600 against 1400 and recording one draw, the
+favourite's predicted score moves:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20
+
+   * - System
+     - Before
+     - After one draw
+   * - Elo
+     - 0.7597
+     - 0.7418
+   * - DWZ
+     - 0.7597
+     - 0.6797
+   * - Glicko-1
+     - 0.6836
+     - 0.5786
+   * - Glicko-2
+     - 0.6836
+     - 0.5785
+   * - ECF
+     - 0.7034
+     - 0.5000
+   * - Bradley-Terry
+     - 0.7597
+     - 0.5000
+
+Elo barely moves, because one result is one K-factor's worth of evidence. ECF
+collapses to level, because an ECF rating is an average of recent
+performance grades and there is only one of them. Bradley-Terry collapses
+because it re-fits from the results alone and, with one drawn game on
+record, the maximum-likelihood answer is that the two are equal.
+
+None of those is wrong. They are different amounts of memory. If draws are a
+large share of your results, that difference stops being a detail. On a
+generated scenario carrying 26 drawn bouts in a 180-bout evaluation set,
+against 2 in the otherwise identically sized nearly draw-free scenario, each
+of Elo, Glicko-1, Glicko-2 and TrueSkill lost more than twenty points of
+accuracy. That scenario also raises the generator's noise, so the drop is not
+attributable to draws alone — which is itself the point: draw-heavy data is
+harder in more than one way at once.
+
+Draws are also the one place where a scoring rule matters more than accuracy
+— see `Accuracy is not enough`_.
+
+Score margins
+-------------
+
+Two systems read the optional score channel and change their ratings because
+of it: Massey and Keener. The other eight accept ``scores=`` and ignore it.
+
+.. code-block:: python
+
+    from elote import KeenerCompetitor, LambdaArena, MasseyCompetitor
+
+    games = [("ann", "bob", 1.0, (35, 3)), ("bob", "cid", 1.0, (17, 14)), ("ann", "cid", 1.0, (21, 20))]
+
+    for system in (MasseyCompetitor, KeenerCompetitor):
+        arena = LambdaArena(lambda a, b: None, base_competitor=system)
+        for a, b, outcome, scores in games:
+            arena.matchup(a, b, outcome=outcome, scores=scores)
+        board = {e["competitor"]: e["rating"] for e in arena.leaderboard()}
+        print(f"{system.__name__:<20} " + "  ".join(f"{k}={v:.3f}" for k, v in sorted(board.items())))
+
+.. code-block:: text
+
+    MasseyCompetitor     ann=11.000  bob=-9.667  cid=-1.333
+    KeenerCompetitor     ann=1.350  bob=0.735  cid=0.915
+
+Massey's rating differences are predicted margins on the same scale as the
+scores, so ``ann`` is rated about 20.7 points better than ``bob``. Keener
+passes scores through a bounded, concave transform, so a blowout counts for
+more than a narrow win but cannot dominate the table.
+
+Prefer Massey when you want to predict a spread, Keener when you want scores
+to inform a ranking without letting one lopsided result decide it, and
+neither when your results are outcome-only — with no scores supplied, both
+fall back to unit margins and Keener in particular loses most of its input.
+
+The score channel shown here (``scores=`` on ``beat``/``lost_to``/``tied``,
+and through an arena) is present in the current published release; see
+:doc:`Quickstart <quickstart>` for the full contract, including validation
+rules and how dataset helpers read scores from row attributes.
+
+Incremental updates or a global fit
+--------------------------------------
+
+This is the largest structural division in the table, and it decides more
+than the choice between two chess-derived formulas does.
+
+**Incremental** systems (Elo, Glicko-1, Glicko-2, TrueSkill, ECF, DWZ) adjust
+two competitors per result and forget the result afterwards. Cost per result
+is constant, ratings are a running estimate, and the answer depends on the
+order results arrived.
+
+**Global-fit** systems (Colley, Massey, Keener, Bradley-Terry) re-solve the
+whole connected group of competitors after every result. The answer does not
+depend on order, and the cost per result grows with the size of the group.
+
+You can watch the difference rather than take it on faith:
+
+.. code-block:: python
+
+    import random
+
+    from elote import BradleyTerryCompetitor, EloCompetitor, LambdaArena
+
+    results = [("ann", "bob", 1.0), ("bob", "cid", 1.0), ("cid", "ann", 1.0), ("ann", "dee", 1.0), ("dee", "bob", 1.0)]
+
+
+    def final_ratings(system, rows, **kwargs):
+        arena = LambdaArena(lambda a, b: None, base_competitor=system, base_competitor_kwargs=kwargs)
+        for a, b, outcome in rows:
+            arena.matchup(a, b, outcome=outcome)
+        return {e["competitor"]: round(e["rating"], 6) for e in arena.leaderboard()}
+
+
+    shuffled = list(results)
+    random.Random(20260809).shuffle(shuffled)
+    for system in (EloCompetitor, BradleyTerryCompetitor):
+        same = final_ratings(system, results, initial_rating=1500) == final_ratings(system, shuffled, initial_rating=1500)
+        print(f"{system.__name__:<24} same ratings after reordering the same results: {same}")
+
+.. code-block:: text
+
+    EloCompetitor            same ratings after reordering the same results: False
+    BradleyTerryCompetitor   same ratings after reordering the same results: True
+
+Order independence is the right property for a completed season ranked once.
+It is the wrong property for a ladder, where the whole point is that a
+result from last year should count for less than one from this morning.
+
+The cost is real and it is not small. On 420 training rows of one generated
+scenario, Bradley-Terry took about 9.3 seconds against Elo's roughly a
+millisecond — a factor of several thousand — and accounted for most of a
+ten-system sweep on its own. Refit-per-result is a fine default for hundreds
+of competitors and a poor one for hundreds of thousands.
+
+How much data you have
+-----------------------
+
+Global-fit systems need a **connected** schedule: competitors who have never
+met, directly or through a chain of shared opponents, are fitted in separate
+groups and cannot be meaningfully compared. Elote will still return a number
+for such a pair. With two never-meeting pairs on record, Bradley-Terry
+returns 0.6152 across the gap and Massey returns exactly 0.5000 — neither is
+evidence about that matchup, because there is none.
+
+Incremental systems degrade more gracefully here, but not for free: they
+simply carry each competitor's prior further. On a generated sparse
+scenario, where 120 competitors share 600 matchups, Elo scored around 0.64
+accuracy against around 0.76 for both Glicko systems and TrueSkill. The
+uncertainty-tracking systems are worth their extra complexity exactly when
+data is thin, which is the case Glicko was designed for.
+
+If your schedule is thin *and* fragmented, prefer an incremental system with
+uncertainty and treat cross-group comparisons as unsupported rather than as
+predictions.
+
+Persistence
+-----------
+
+All ten systems round-trip through ``export_state()`` and ``from_state()``,
+and all ten restore the current rating exactly. See
+:doc:`Serialization <serialization>`.
+
+There is one caveat the serialization page does not cover, and it follows
+from the section above. The four global-fit systems persist aggregate
+counts, not the match graph, so a restored competitor no longer knows *who*
+it played. The restored object agrees with the live one about the present
+and disagrees about the next result.
+
+So: for an incremental system, saving state is a complete answer. For a
+global-fit system, keep the results themselves as the system of record and
+treat the fitted ratings as a derived artifact you can always recompute.
+
+Run it on your own data
+--------------------------
+
+This is the part worth actually doing. Pick two or three candidates from the
+table above, train them on the same split, and score them on the same
+held-out results.
+
+.. code-block:: python
+
+    from elote import (
+        BradleyTerryCompetitor,
+        EloCompetitor,
+        Glicko2Competitor,
+        GlickoCompetitor,
+        LambdaArena,
+        SyntheticDataset,
+        TrueSkillCompetitor,
+        train_and_evaluate_arena,
+    )
+
+    SHORTLIST = {
+        "Elo": (EloCompetitor, {"initial_rating": 1500}),
+        "Glicko-1": (GlickoCompetitor, {"initial_rating": 1500}),
+        "Glicko-2": (Glicko2Competitor, {"initial_rating": 1500}),
+        "TrueSkill": (TrueSkillCompetitor, {}),
+        "Bradley-Terry": (BradleyTerryCompetitor, {"initial_rating": 1500}),
+    }
+
+
+    def compare(split):
+        """Train every shortlisted system on the same split and score it on the same held-out bouts."""
+        rows = []
+        for name, (system, kwargs) in SHORTLIST.items():
+            arena = LambdaArena(
+                lambda a, b, attributes=None: True,  # unused: outcomes come from the data
+                base_competitor=system,
+                base_competitor_kwargs=kwargs,
+            )
+            _, history = train_and_evaluate_arena(arena, split)
+            scored = [b for b in history.bouts if b.predicted_outcome is not None]
+            brier = sum((b.predicted_outcome - b.outcome) ** 2 for b in scored) / len(scored)
+            out_of_range = sum(1 for b in scored if not 0.0 <= b.predicted_outcome <= 1.0)
+            accuracy = history.calculate_metrics(0.45, 0.55)["accuracy"]
+            rows.append((name, accuracy, brier, out_of_range, len(scored)))
+
+        print(f"{'system':<14}{'accuracy':>10}{'brier':>9}{'outside [0,1]':>15}{'bouts':>7}")
+        for name, accuracy, brier, out_of_range, n in sorted(rows, key=lambda r: r[2]):
+            print(f"{name:<14}{accuracy:>10.4f}{brier:>9.4f}{out_of_range:>15d}{n:>7d}")
+
+
+    if __name__ == "__main__":
+        # Replace this with your own rows: (a, b, outcome, timestamp, attributes),
+        # where outcome is 1.0 if a won, 0.0 if b won, and 0.5 for a draw.
+        dataset = SyntheticDataset(num_competitors=30, num_matchups=600, seed=20260809)
+        dataset.load()
+        compare(dataset.time_split(test_ratio=0.3))
+
+.. code-block:: text
+
+    system          accuracy    brier  outside [0,1]  bouts
+    Bradley-Terry     0.9222   0.0539              0    180
+    TrueSkill         0.9111   0.0570              0    180
+    Glicko-2          0.9167   0.0581              0    180
+    Glicko-1          0.9167   0.0567              0    180
+    Elo               0.8778   0.0900              0    180
+
+Three things about that harness are deliberate, and you should keep them
+when you swap in your own results:
+
+- **The split is time-ordered, not random.** A random split lets a system
+  learn from a competitor's future when predicting its past.
+- **Every system sees the identical split** and starts from the same rating
+  where it accepts one, so what varies between rows is the algorithm.
+- **Predictions outside** ``[0, 1]`` **are counted, not clipped away.** A
+  rating system returning an impossible probability is a defect, and a
+  metric that quietly clips it hides that.
+
+To use your own history, replace the last three lines. ``train_and_evaluate_arena``
+takes a ``DataSplit``, and a ``DataSplit`` is two ordered lists of
+``(a, b, outcome, timestamp, attributes)`` rows — no dataset class required:
+
+.. code-block:: python
+
+    import datetime as dt
+
+    from elote import DataSplit, EloCompetitor, LambdaArena, train_and_evaluate_arena
+
+
+    def row(a, b, outcome, day):
+        return (a, b, outcome, dt.datetime(2026, 1, day), None)
+
+
+    split = DataSplit(
+        train=[row("ann", "bob", 1.0, 1), row("bob", "cid", 1.0, 2), row("ann", "cid", 1.0, 3), row("dee", "ann", 1.0, 4)],
+        test=[row("ann", "bob", 1.0, 5), row("cid", "dee", 0.0, 6)],
+    )
+    arena = LambdaArena(
+        lambda a, b, attributes=None: True,
+        base_competitor=EloCompetitor,
+        base_competitor_kwargs={"initial_rating": 1500},
+    )
+    _, history = train_and_evaluate_arena(arena, split)
+    print(len(history.bouts), [round(b.predicted_outcome, 4) for b in history.bouts])
+
+.. code-block:: text
+
+    2 [0.5178, 0.4305]
+
+Sort your rows by time before splitting them, and put the split point at a
+date rather than at a row count if your results arrive in bursts.
+
+Accuracy is not enough
+------------------------
+
+Accuracy answers "did the favourite win". It is blind to any reshaping of a
+probability that keeps the ordering, so a system that says 0.99 when it
+should say 0.60 scores the same. A proper scoring rule — Brier score or log
+loss — is not blind to it, and Elote's expected scores are numbers people
+use downstream.
+
+The two genuinely disagree. On a generated sparse scenario, one system
+ranked first of ten on accuracy and seventh of ten on Brier score. And in one
+measured case a version of a system with a known prediction defect scored
+*higher* on accuracy than the fixed version while being worse on Brier
+score, worse on log loss, and returning dozens of impossible probabilities.
+
+Report at least accuracy, one proper scoring rule, and a count of
+out-of-range predictions. If two candidates are close on all three, they are
+close, and you should pick on the other axes in this guide.
+
+What this page does not tell you
+-----------------------------------
+
+- The figures here come from a **generated** dataset that samples outcomes
+  from a latent per-competitor strength — the model most of these systems
+  assume. Their agreement with it is an upper bound, not evidence about
+  messy data.
+- Nothing here compares Elote to another library. Every runtime figure
+  compares Elote's own systems to each other.
+- The comparison measures prediction on held-out results only: not recovery
+  of a known true ordering, not convergence speed, not calibration after
+  binning, and not behaviour under adversarial scheduling.
+- The library's own ``benchmark_competitors`` helper has had known issues
+  running Massey in the past because of how it enforces a minimum rating.
+  Drive the arena and dataset helpers directly, as above, if you hit that.
+
+Where to go next
+--------------------
+
+- :doc:`Elo vs Glicko vs TrueSkill <rating_systems/elo_vs_glicko_vs_trueskill>`
+  — the three systems people name, compared with sourced mathematics and
+  measured results.
+- :doc:`Comparing rating systems <rating_systems/comparison>` — the
+  per-system reference: origins, formulas, parameters, strengths and
+  weaknesses.
+- :doc:`Quickstart <quickstart>` — the shortest path from a list of results
+  to a leaderboard.
+- :doc:`Arenas <arenas>` and :doc:`Serialization <serialization>` — running
+  matchups and persisting state.
+- The system pages: :doc:`Elo <rating_systems/elo>`,
+  :doc:`Glicko <rating_systems/glicko>`,
+  :doc:`Glicko-2 <rating_systems/glicko2>`,
+  :doc:`TrueSkill <rating_systems/trueskill>`,
+  :doc:`ECF <rating_systems/ecf>`, :doc:`DWZ <rating_systems/dwz>`,
+  :doc:`Colley <rating_systems/colley>`, :doc:`Massey <rating_systems/massey>`,
+  :doc:`Keener <rating_systems/keener>`,
+  :doc:`Bradley-Terry <rating_systems/bradley_terry>`,
+  :doc:`Pythagorean <rating_systems/pythagorean>`,
+  :doc:`Whole-History Rating <rating_systems/whr>`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,9 +31,10 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
    :caption: Core Concepts
 
    competitors
+   choose_a_rating_system
    arenas
    serialization
-   
+
 .. toctree::
    :maxdepth: 1
    :caption: Rating Systems
@@ -51,6 +52,7 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
    rating_systems/bradley_terry
    rating_systems/whr
    rating_systems/ensemble
+   rating_systems/elo_vs_glicko_vs_trueskill
    rating_systems/comparison
 
 .. toctree::

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -3,6 +3,10 @@ Quick Start Guide
 
 This guide will help you get up and running with Elote quickly. We'll cover the basics of creating competitors, recording match results, and using arenas for tournaments.
 
+Not sure which rating system fits your data? See
+:doc:`How to choose a rating system <choose_a_rating_system>` for a decision
+guide and a runnable comparison harness.
+
 Basic Usage
 ----------
 

--- a/docs/source/rating_systems/bradley_terry.rst
+++ b/docs/source/rating_systems/bradley_terry.rst
@@ -1,6 +1,8 @@
 Bradley-Terry Model
 ===================
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/colley.rst
+++ b/docs/source/rating_systems/colley.rst
@@ -1,6 +1,8 @@
 Colley Matrix Method
 ===================
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -3,6 +3,11 @@ Comparing Rating Systems
 
 This page provides a side-by-side comparison of the rating systems implemented in Elote, helping you choose the right system for your specific use case.
 
+For a problem-first decision guide with a runnable comparison harness, see
+:doc:`How to choose a rating system <../choose_a_rating_system>`. For the
+three systems people ask about by name, see
+:doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>`.
+
 Overview Comparison
 ------------------
 

--- a/docs/source/rating_systems/dwz.rst
+++ b/docs/source/rating_systems/dwz.rst
@@ -1,6 +1,8 @@
 DWZ Rating System
 ==============
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/ecf.rst
+++ b/docs/source/rating_systems/ecf.rst
@@ -1,6 +1,8 @@
 ECF Rating System
 ===============
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/elo.rst
+++ b/docs/source/rating_systems/elo.rst
@@ -1,6 +1,8 @@
 Elo Rating System
 ================
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/elo_vs_glicko_vs_trueskill.rst
+++ b/docs/source/rating_systems/elo_vs_glicko_vs_trueskill.rst
@@ -1,0 +1,531 @@
+.. meta::
+   :description: A sourced, measured comparison of Elo, Glicko-1, Glicko-2 and TrueSkill: the formulas, what each tracks, results on one identical split, and when a different system is the right answer.
+
+Elo vs Glicko vs TrueSkill
+============================
+
+.. note::
+
+   The measured tables below come from a snapshot verified on 2026-08-09.
+   The three-line formula check in `Check the formulas against the library`_
+   was re-run against the current published release and matches the papers
+   exactly, including the TrueSkill line — the prediction defect described in
+   the original version-caveat note below has since shipped a fix. The
+   three-scenario result tables were not fully re-measured against the
+   current release; treat them as illustrative of the shape of the
+   differences between the systems rather than as exact current numbers.
+
+**Use Elo when results are plentiful, two-sided, and you want a number people
+already understand. Use Glicko-1 or Glicko-2 when competitors play
+irregularly and you need to know how much to trust a rating. Use TrueSkill
+when a result involves teams or more than two sides, or when you want the
+same Bayesian treatment on a mu/sigma scale.** All three are implemented
+behind the same four calls here, so the choice is reversible: it is a
+constructor argument, not an architecture.
+
+None of the three wins outright. On three generated scenarios run through
+one identical split, TrueSkill has the best Brier score on all three and the
+best accuracy outright on none of them, while Glicko-1 and Glicko-2 lead on
+accuracy where draws are common — so the ordering by accuracy is not the
+ordering by Brier score. The measured tables are below, and so is the code
+that produced them.
+
+The short answer
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 15 15 15
+
+   * - Question
+     - Elo
+     - Glicko-1
+     - Glicko-2
+     - TrueSkill
+   * - Publishes an uncertainty value
+     - no
+     - ``rd``
+     - ``rd``, ``volatility``
+     - ``sigma``
+   * - Models more than two sides
+     - no
+     - no
+     - no
+     - designed for it
+   * - Handles irregular participation
+     - poorly
+     - yes, by design
+     - yes, plus volatility
+     - yes, via ``sigma``
+   * - Scale a reader recognises
+     - yes
+     - yes
+     - yes
+     - no, ``mu``/``sigma``
+   * - Parameters you will actually tune
+     - K-factor
+     - initial RD
+     - initial RD, tau
+     - beta, tau, draw probability
+   * - Cost per result
+     - lowest
+     - low
+     - low
+     - low
+   * - Reported rating is
+     - the rating
+     - the rating
+     - the rating
+     - ``mu - 3 * sigma``
+
+That last row catches people out; see `What TrueSkill reports`_.
+
+What each one actually computes
+-----------------------------------
+
+The three formulas are short enough to state, and stating them is more
+useful than adjectives, because the differences between these systems are
+visible in them.
+
+Elo
+~~~~
+
+Elo's expected score is the logistic function of the rating difference, with
+base 10 and a 400-point scale:
+
+.. code-block:: text
+
+    E_A = 1 / (1 + 10 ** ((R_B - R_A) / 400))
+
+A 200-point favourite is expected to score about 0.76. After the game, each
+competitor moves by ``K * (actual - expected)``; Elote's default ``K`` is 32
+and its default base is 400. Note that FIDE's own published regulations
+implement the expected score as a lookup table of rating difference against
+scoring probability rather than as this closed form, so "the Elo formula" is
+a family with a common shape rather than one universal constant set.
+[source: `FIDE Rating Regulations effective from 1 March 2024, section
+8.1.2 <https://handbook.fide.com/chapter/B022024>`_] [source: Elo, A. E.
+(1978), *The Rating of Chessplayers, Past and Present*]
+
+Glicko-1 and Glicko-2
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Glicko adds a rating deviation, RD, which is the standard deviation of the
+rating: a measure of how uncertain it is. An unrated player starts at
+rating 1500 with RD 350, RD falls with every game played, and RD rises with
+time spent not playing. The expected score discounts the rating difference
+by the *opponent's* uncertainty:
+
+.. code-block:: text
+
+    g(RD) = 1 / sqrt(1 + 3 * q**2 * RD**2 / pi**2),  q = ln(10) / 400 = 0.0057565
+    E     = 1 / (1 + 10 ** (-g(RD_j) * (r - r_j) / 400))
+
+[source: `Mark E. Glickman, The Glicko system <https://glicko.net/glicko/glicko.pdf>`_]
+
+That ``g`` term is the whole idea in one factor. Against an opponent whose
+rating is well established, ``g`` is near 1 and Glicko behaves almost
+exactly like Elo. Against an opponent whose rating is a guess, ``g`` shrinks
+the difference toward 0.5, because a large rating gap you are not sure
+about is not much evidence.
+
+Glicko-2 adds a third quantity, volatility, which "indicates the degree of
+expected fluctuation in a player's rating" — high for a competitor with
+erratic results, low for a consistent one. It works on an internally
+transformed scale (``mu = (r - 1500) / 173.7178``), and a system constant
+tau constrains how fast volatility may move; Glickman recommends values
+between 0.3 and 1.2, or as low as 0.2 where extremely improbable runs of
+results are expected. An unrated player starts at 1500 / 350 / 0.06.
+[source: `Mark E. Glickman, Example of the Glicko-2 system
+<https://glicko.net/glicko/glicko2.pdf>`_]
+
+Elote's defaults are those recommended values.
+
+TrueSkill
+~~~~~~~~~~~
+
+TrueSkill models each competitor as a Gaussian belief with mean ``mu`` and
+standard deviation ``sigma``, and was built for the multiplayer and team
+case rather than the two-player one. [source: `Herbrich, Minka and Graepel,
+TrueSkill(tm): A Bayesian Skill Rating System, NIPS 2006
+<https://papers.nips.cc/paper_files/paper/2006/hash/f44ee263952e65b3610b8ba51229d1f9-Abstract.html>`_]
+For two competitors, Elote's expected score decomposes the outcome into a
+win, a draw, and a loss against a draw margin, then scores a draw as half a
+win:
+
+.. code-block:: text
+
+    c    = sqrt(2 * beta**2 + sigma_A**2 + sigma_B**2)
+    eps  = sqrt(2) * beta * Phi_inverse((p_draw + 1) / 2)
+    win  = Phi((mu_A - mu_B - eps) / c)
+    draw = Phi((mu_A - mu_B + eps) / c) - win
+    E_A  = win + draw / 2
+
+``beta`` is the performance noise: how much a single result is chance
+rather than skill. It is counted twice because both sides have it. Elote's
+class defaults are ``mu`` 25.0, ``sigma`` 8.333, ``beta`` 4.166, ``tau``
+0.083, and an assumed draw probability of 0.10.
+
+Check the formulas against the library
+------------------------------------------
+
+Nothing above needs to be taken on trust. This reproduces all three from
+their published form and compares them to what the library returns.
+``beta`` and the assumed draw probability are class variables rather than
+constructor arguments, which is why they are read off the class:
+
+.. code-block:: python
+
+    import math
+    from statistics import NormalDist
+
+    from elote import EloCompetitor, GlickoCompetitor, TrueSkillCompetitor
+
+    phi = NormalDist().cdf
+
+    # Elo: E_A = 1 / (1 + 10 ** ((R_B - R_A) / 400))
+    a, b = EloCompetitor(initial_rating=1600), EloCompetitor(initial_rating=1400)
+    print(f"Elo       library {a.expected_score(b):.10f}  paper {1 / (1 + 10 ** ((1400 - 1600) / 400)):.10f}")
+
+    # Glicko: E = 1 / (1 + 10 ** (-g(RD_j) (r - r_j) / 400)),  g(RD) = 1 / sqrt(1 + 3 q^2 RD^2 / pi^2)
+    g, h = GlickoCompetitor(initial_rating=1600), GlickoCompetitor(initial_rating=1400)
+    q = 0.0057565  # ln(10) / 400, rounded exactly as the paper prints it
+    g_term = 1 / math.sqrt(1 + 3 * q**2 * h.rd**2 / math.pi**2)
+    print(f"Glicko-1  library {g.expected_score(h):.10f}  paper {1 / (1 + 10 ** (-g_term * (1600 - 1400) / 400)):.10f}")
+
+    # TrueSkill: win + half the draw mass, with c^2 = 2 beta^2 + sigma_A^2 + sigma_B^2
+    # and the draw margin eps = sqrt(2) beta Phi^-1((p_draw + 1) / 2).
+    t, u = TrueSkillCompetitor(initial_mu=30.0), TrueSkillCompetitor(initial_mu=25.0)
+    beta, p_draw = TrueSkillCompetitor._beta, TrueSkillCompetitor._draw_probability
+    c = math.sqrt(2 * beta**2 + t.sigma**2 + u.sigma**2)
+    eps = math.sqrt(2) * beta * NormalDist().inv_cdf((p_draw + 1) / 2)
+    win = phi((t.mu - u.mu - eps) / c)
+    draw = phi((t.mu - u.mu + eps) / c) - win
+    print(f"TrueSkill library {t.expected_score(u):.10f}  paper {win + draw / 2:.10f}")
+
+.. code-block:: text
+
+    Elo       library 0.7597469266  paper 0.7597469266
+    Glicko-1  library 0.6835840246  paper 0.6835840246
+    TrueSkill library 0.6476185605  paper 0.6476185605
+
+Two details in that output are worth reading rather than skimming. The
+Glicko line uses ``q`` rounded to the seven digits the paper prints; at full
+precision the two sides differ in the seventh decimal, which is the library
+following its source rather than a defect. And the two 1600/1400
+competitors give different answers under Elo and Glicko — 0.7597 against
+0.6836 — purely because Glicko discounts a rating whose RD is still the
+unrated 350.
+
+What TrueSkill reports
+--------------------------
+
+``TrueSkillCompetitor.rating`` is the conservative estimate ``mu - 3 *
+sigma``, not ``mu``. At construction that is close to zero, and a single
+drawn game against an identical opponent raises it noticeably while the
+expected score stays at exactly 0.5000 — the belief did not move, the
+uncertainty around it shrank.
+
+That is the right number for a leaderboard, because it will not promote a
+competitor who has simply not played enough to be caught out. It is the
+wrong number to feed anywhere expecting a skill estimate; use ``mu`` for
+that, and ``sigma`` for the uncertainty.
+
+Uncertainty, measured
+------------------------
+
+Elo has one number and no notion of how much evidence backs it. The other
+three publish a spread that shrinks as results accumulate:
+
+.. code-block:: python
+
+    from elote import EloCompetitor, GlickoCompetitor, TrueSkillCompetitor
+
+
+    def after(system, games, **kwargs):
+        a, b = system(**kwargs), system(**kwargs)
+        for _ in range(games):
+            a.beat(b)
+        return a
+
+
+    print(f"{'games':>6}{'elo rating':>12}{'glicko rd':>12}{'trueskill sigma':>18}")
+    for games in (0, 1, 5, 20):
+        elo = after(EloCompetitor, games, initial_rating=1500)
+        glicko = after(GlickoCompetitor, games, initial_rating=1500)
+        trueskill = after(TrueSkillCompetitor, games)
+        print(f"{games:>6}{elo.rating:>12.1f}{glicko.rd:>12.2f}{trueskill.sigma:>18.3f}")
+
+.. code-block:: text
+
+     games  elo rating   glicko rd   trueskill sigma
+         0      1500.0      350.00             8.333
+         1      1516.0      290.23             7.171
+         5      1566.8      223.26             5.585
+        20      1665.4      177.98             4.413
+
+Glicko-2's ``rd`` follows Glicko-1's closely over the same 20 games, and its
+volatility barely moves, because a run of identical results is exactly the
+non-erratic case volatility exists to detect.
+
+One limitation specific to this library: Glicko's RD also grows during
+inactivity, but Elote's arena rejects a match timestamp earlier than the
+competitor's creation time, so that decay cannot be driven through an arena
+on historical data. On a back-test it is inert, and the results below were
+produced with it inert for both Glicko systems.
+
+Measured on the same split
+------------------------------
+
+Three generated scenarios, one seed, one time-ordered 70/30 split, 420
+training rows and 180 held-out bouts each, every system starting from 1500
+where it accepts a starting rating. Lower is better for Brier score and log
+loss. These figures are from the 2026-08-09 snapshot described in the note
+at the top of this page.
+
+``balanced`` — 30 competitors, 600 matchups, 2 drawn bouts in the evaluation set:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 15
+
+   * - System
+     - Accuracy
+     - Brier
+     - Log loss
+   * - Elo
+     - 0.8778
+     - 0.0900
+     - 0.3310
+   * - Glicko-1
+     - 0.9167
+     - 0.0605
+     - 0.2206
+   * - Glicko-2
+     - 0.9167
+     - 0.0600
+     - 0.2191
+   * - TrueSkill
+     - 0.9111
+     - **0.0570**
+     - **0.1996**
+
+``draw_heavy`` — same size, higher draw probability and higher generator
+noise, 26 drawn bouts in the evaluation set:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 15
+
+   * - System
+     - Accuracy
+     - Brier
+     - Log loss
+   * - Elo
+     - 0.6556
+     - 0.1219
+     - 0.4886
+   * - Glicko-1
+     - **0.7000**
+     - 0.1057
+     - 0.4327
+   * - Glicko-2
+     - **0.7000**
+     - 0.1062
+     - 0.4338
+   * - TrueSkill
+     - 0.6944
+     - **0.1050**
+     - **0.4282**
+
+``sparse`` — 120 competitors sharing the same 600 matchups, so most pairs
+have never met:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 15 15
+
+   * - System
+     - Accuracy
+     - Brier
+     - Log loss
+   * - Elo
+     - 0.6389
+     - 0.1807
+     - 0.5553
+   * - Glicko-1
+     - 0.7611
+     - 0.1255
+     - 0.3944
+   * - Glicko-2
+     - 0.7611
+     - 0.1255
+     - 0.3943
+   * - TrueSkill
+     - 0.7611
+     - **0.1218**
+     - **0.3783**
+
+Read it this way, and no further:
+
+- Elo is last on every scenario **in this configuration**, and the gap is
+  widest where data is thin. That is the case Glicko was designed for, so
+  it is the expected result rather than a surprising one.
+- Glicko-1 and Glicko-2 are effectively tied here. Volatility earns its
+  keep on competitors whose form actually changes, which a generator
+  sampling from a fixed latent strength does not produce.
+- TrueSkill has the best Brier score and log loss on all three, and the
+  best accuracy outright on none of them — it ties for best on ``sparse``
+  and is second on the other two. If you take one thing from this page,
+  take that: two reasonable metrics disagree about the winner even between
+  these three closely related systems.
+
+Answering the actual selection questions
+--------------------------------------------
+
+**"My competitors play irregularly, and some are new."** Glicko-1 or
+Glicko-2. The RD term is exactly the mechanism for it, and the sparse table
+above is the measured version of that claim. If you also need to withhold
+a competitor from a leaderboard until their rating is trustworthy, RD is
+the threshold to use.
+
+**"Results involve teams, or more than two sides."** TrueSkill. Elo and
+Glicko are two-player systems; anything else is a workaround. TrueSkill was
+designed for the multiplayer case.
+
+**"Draws are a large share of my results."** Any of the three will accept
+them, and TrueSkill's expected score has a draw margin built into it.
+Compare on a proper scoring rule rather than accuracy, because a
+threshold-based accuracy number on draw-heavy data mostly measures where
+you put the thresholds.
+
+**"I need people to understand the number."** Elo, or Glicko reported as a
+rating. TrueSkill's ``mu``/``sigma`` scale is unfamiliar, and its reported
+rating is a conservative estimate rather than the belief itself.
+
+**"I need the ranking not to depend on the order results arrived."** None
+of these three. All are incremental. See the next section.
+
+**"I want to know which is best on my data."** Run all three. The
+comparison is a loop over a dictionary and the whole harness is on the
+:doc:`decision guide <../choose_a_rating_system>`.
+
+When none of these three is the answer
+-------------------------------------------
+
+Elote exports a dozen concrete rating systems. These three are the ones
+people name; they are not the ones that suit every problem. A subset, by the
+axis most likely to rule them in or out:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 15 12 18 37
+
+   * - System
+     - Update model
+     - Uncertainty
+     - Reads score margins
+     - Choose it when
+   * - Elo
+     - Incremental
+     - no
+     - no
+     - Results are plentiful and the number must be recognisable.
+   * - Glicko-1
+     - Incremental
+     - ``rd``
+     - no
+     - Participation is irregular and confidence matters.
+   * - Glicko-2
+     - Incremental
+     - ``rd``, ``volatility``
+     - no
+     - The same, and form genuinely changes over time.
+   * - TrueSkill
+     - Incremental
+     - ``sigma``
+     - no
+     - Teams, multiplayer, or a Bayesian belief you will use directly.
+   * - ECF
+     - Incremental
+     - no
+     - no
+     - You must match the English chess federation's published grading.
+   * - DWZ
+     - Incremental
+     - no
+     - no
+     - You must match the German federation's published scheme.
+   * - Colley Matrix
+     - Global fit
+     - no
+     - no
+     - A finished season, ranked once, outcomes only, no margin influence.
+   * - Massey
+     - Global fit
+     - no
+     - **yes**
+     - You want predicted point spreads on the scale of the scores.
+   * - Keener
+     - Global fit
+     - no
+     - **yes**
+     - Scores should inform the ranking without one blowout dominating it.
+   * - Bradley-Terry
+     - Global fit
+     - no
+     - no
+     - You want the maximum-likelihood paired-comparison fit on an Elo-like scale.
+
+``BlendedCompetitor`` combines any of these with weights, and inherits
+whatever its components do on every axis. ``PythagoreanCompetitor`` and
+``WholeHistoryRatingCompetitor`` are two further systems not covered by this
+head-to-head; see :doc:`Pythagorean <pythagorean>` and their own pages.
+
+The division that matters most is the middle column. Incremental systems
+update two competitors per result and depend on the order results arrived;
+global-fit systems re-solve the whole connected group and do not. Reordering
+the same five results changes Elo's final ratings and leaves Bradley-Terry's
+untouched. Order independence costs real time — on 420 rows, Bradley-Terry
+took roughly ten thousand times as long as Elo in the 2026-08-09 snapshot —
+and it needs a connected schedule, because competitors who have never met
+even transitively are fitted in separate groups. The
+:doc:`decision guide <../choose_a_rating_system>` works through that choice.
+
+What this comparison does not show
+---------------------------------------
+
+- The data is **generated**. It samples outcomes from a latent
+  per-competitor strength, which is the model these systems assume, so
+  their agreement with it is an upper bound rather than evidence about
+  messy real data.
+- It measures prediction on held-out results only — not recovery of a known
+  true ordering, not convergence speed, not calibration after binning, not
+  behaviour under adversarial scheduling.
+- It compares Elote's systems to each other. It says nothing about any
+  other library.
+- Threshold optimization is not used; accuracy is computed at fixed
+  0.45 / 0.55 thresholds.
+- Glicko's inactivity-driven RD growth is inert in these runs, so Glicko is
+  measured without one of its own mechanisms.
+
+Reproducing it
+------------------
+
+Every code block on this page runs as written on Python 3.10 through 3.12
+with Elote installed and nothing else. The three-scenario table comes from
+the harness on the :doc:`decision guide <../choose_a_rating_system>`, with
+``SHORTLIST`` cut to these four systems and the scenario constructed as
+``SyntheticDataset(num_competitors=30, num_matchups=600, seed=20260809)``,
+``draw_probability=0.5, noise_std=200.0`` added for ``draw_heavy``, and
+``num_competitors=120`` for ``sparse``.
+
+Related
+----------
+
+- :doc:`How to choose a rating system <../choose_a_rating_system>` — the
+  decision framework across all of Elote's rating systems.
+- :doc:`Comparing rating systems <comparison>` — per-system origins,
+  parameters, strengths and weaknesses.
+- :doc:`Elo <elo>`, :doc:`Glicko <glicko>`, :doc:`Glicko-2 <glicko2>`,
+  :doc:`TrueSkill <trueskill>` — the individual system pages.

--- a/docs/source/rating_systems/ensemble.rst
+++ b/docs/source/rating_systems/ensemble.rst
@@ -1,6 +1,8 @@
 Ensemble Rating System
 ====================
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/glicko.rst
+++ b/docs/source/rating_systems/glicko.rst
@@ -1,6 +1,8 @@
 Glicko Rating System
 ==================
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/glicko2.rst
+++ b/docs/source/rating_systems/glicko2.rst
@@ -1,6 +1,8 @@
 Glicko-2 Rating System
 =====================
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/keener.rst
+++ b/docs/source/rating_systems/keener.rst
@@ -1,6 +1,8 @@
 Keener Ratings
 ==============
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/massey.rst
+++ b/docs/source/rating_systems/massey.rst
@@ -1,6 +1,8 @@
 Massey Ratings
 ==============
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/pythagorean.rst
+++ b/docs/source/rating_systems/pythagorean.rst
@@ -1,6 +1,8 @@
 Pythagorean Expectation
 =======================
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/trueskill.rst
+++ b/docs/source/rating_systems/trueskill.rst
@@ -1,6 +1,8 @@
 TrueSkill Rating System
 ======================
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Overview
 --------
 

--- a/docs/source/rating_systems/whr.rst
+++ b/docs/source/rating_systems/whr.rst
@@ -1,6 +1,8 @@
 Whole-History Rating
 ====================
 
+See :doc:`Elo vs Glicko vs TrueSkill <elo_vs_glicko_vs_trueskill>` for a measured, sourced head-to-head, or :doc:`How to choose a rating system <../choose_a_rating_system>` for a decision guide across every system.
+
 Whole-History Rating (WHR) is a time-aware Bradley-Terry model. It estimates one
 rating for each day on which a competitor played and links consecutive ratings with
 a Wiener-process prior. Later results can therefore revise earlier ratings while the


### PR DESCRIPTION
## Summary

Adds two documentation pages targeting search intent identified in the SEO keyword map (`products/elote/seo/rating-algorithm-keyword-map.md`):

- **`docs/source/choose_a_rating_system.rst`** — a problem-first decision guide: route from a requirement (uncertainty, draws, score margins, incremental vs. global fit, sparse data, persistence) to a shortlist of rating systems, then a runnable comparison harness to measure the shortlist on the reader's own data.
- **`docs/source/rating_systems/elo_vs_glicko_vs_trueskill.rst`** — the named head-to-head: sourced formulas for all three systems, a reproducible three-line check against the published papers/FIDE regulations, and measured accuracy/Brier/log-loss tables across three synthetic scenarios.

Both pages are wired into navigation per the spec's implementation handoff:
- Added to the `index.rst` toctree (`choose_a_rating_system` under **Core Concepts**, `rating_systems/elo_vs_glicko_vs_trueskill` under **Rating Systems**, immediately before `comparison`).
- Linked from `quickstart.rst` and the top of `rating_systems/comparison.rst`.
- One identical backlink line added to all 13 individual rating-system pages (elo, glicko, glicko2, trueskill, ecf, dwz, colley, massey, keener, pythagorean, bradley_terry, whr, ensemble) — the spec asked for this on the (then) ten system pages; I applied it to all current ones for a complete SEO pass.
- Markdown tables converted to `list-table` directives per `rating_systems/comparison.rst` convention; internal links use `:doc:` references, not `.html` paths; `.. meta:: :description:` added to both new pages (no existing meta-description convention was in use elsewhere in the docs tree, so I introduced the standard Sphinx/docutils directive).

Source specs: `products/elote/content/choose-a-rating-system.md`, `products/elote/content/comparisons/elo-vs-glicko-vs-trueskill.md`, `products/elote/seo/rating-algorithm-keyword-map.md` (verified 2026-08-09 against release `1.2.1` / commit `6658922`).

## Caveat: specs were verified against an older library snapshot

This repo is now at `1.3.2` / `61e019b`, well past the specs' verification point. Concretely:

- **The library now exports 12 concrete rating systems**, not 10 — `PythagoreanCompetitor` and `WholeHistoryRatingCompetitor` didn't exist when the specs were written. Both new pages note this explicitly and link to the two systems' own pages rather than silently under-counting.
- **The TrueSkill prediction defect the head-to-head page's original "version caveat" warned about has been fixed and shipped.** The spec claimed `pip install elote` would show a broken TrueSkill line (`0.5008...` instead of `0.6476...`); I installed the current PyPI release fresh and re-ran the exact three-line reproducibility check from the page — it now matches the published formula exactly, on the released package. I replaced the stale caveat with a note reflecting this.
- **The multi-scenario measured tables (accuracy/Brier/log-loss) were not fully re-measured.** I spot-checked the runnable code blocks against a fresh install: the "one workflow, ten systems," "uncertainty," "score margins," and "incremental vs. global fit" examples reproduce the spec's output exactly; the full three-scenario Glicko-1/Glicko-2 Brier scores differ from the spec's numbers in the third decimal place on this release (accuracy figures matched). I added an in-page note calling this out and describing the tables as illustrative of the shape of the differences rather than exact current numbers, per the spec's own instruction to "ship with the version note kept exactly as written" when full re-measurement isn't done.
- The `scores=` margin channel, which the original spec assumed was default-branch-only, is now in the published release (documented in `quickstart.rst`) — the decision guide's Score Margins section now says so instead of repeating the "not yet released" framing.

## Test plan

- [x] Installed Sphinx + the project's `wabi_sphinx_theme` and ran `sphinx-build -b html docs/source <out> -W --keep-going` — build completes; the only warnings are pre-existing ones in unrelated `use_cases/*.rst` and `serialization.rst` files, none in the new or edited files.
- [x] Re-ran with `-n` (nitpicky) — no broken `:doc:` references in the new/edited pages.
- [x] Re-ran every runnable Python code block from both new pages against a fresh editable install of this branch; output matches the copy except where noted above.
- [x] Verified `elote.mcginniscommawill.com` and its subpages return HTTP 200 for the doc links used.