### PR TITLE
Add rating-system comparison runner, make target, and benchmark docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ htmlcov/
 .benchmarks/
 .coverage*
 .uv.lockbuild/
+rating_system_comparison*.csv
+rating_system_comparison*.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup install install-dev install-datasets test test-cov lint format clean build docs lint-fix test-all benchmark run-example typecheck
+.PHONY: help setup install install-dev install-datasets test test-cov lint format clean build docs lint-fix test-all benchmark compare-systems run-example typecheck
 
 # Default target
 help:
@@ -11,6 +11,7 @@ help:
 	@echo "  make test-cov     - Run tests with coverage"
 	@echo "  make test-all     - Run tests on all supported Python versions using tox"
 	@echo "  make benchmark    - Run performance benchmarks"
+	@echo "  make compare-systems - Compare every rating system on one interface, one split"
 	@echo "  make lint         - Run linting checks"
 	@echo "  make lint-fix     - Run linting checks and fix auto-fixable issues"
 	@echo "  make typecheck    - Run mypy type checking"
@@ -112,7 +113,11 @@ test-all:
 
 # Run benchmarks
 benchmark:
-	uv run pytest tests/test_benchmarks.py -v --benchmark-enable $(PYTEST_ARGS) 
+	uv run pytest tests/test_benchmarks.py -v --benchmark-enable $(PYTEST_ARGS)
+
+# Compare every rating system elote ships, on one interface, on one split
+compare-systems:
+	uv run python scripts/rating_system_comparison.py
 
 # Run an example
 run-example:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Currently implemented rating systems:
 
 You can also combine several systems into a single **Ensemble** (blended) competitor.
 
+Curious how they stack up against each other? Run `make compare-systems` (or
+[`scripts/rating_system_comparison.py`](scripts/rating_system_comparison.py)
+directly) to train every system on the same split and compare accuracy, Brier
+score, and log loss — see the
+[comparison benchmark docs](https://elote.mcginniscommawill.com/rating_systems/comparison_benchmark.html)
+for the methodology and measured results.
+
 ## Installation
 
 ### For Users

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ You can also combine several systems into a single **Ensemble** (blended) compet
 Curious how they stack up against each other? Run `make compare-systems` (or
 [`scripts/rating_system_comparison.py`](scripts/rating_system_comparison.py)
 directly) to train every system on the same split and compare accuracy, Brier
-score, and log loss — see the
-[comparison benchmark docs](https://elote.mcginniscommawill.com/rating_systems/comparison_benchmark.html)
+score, and log loss — see
+[`docs/source/rating_systems/comparison_benchmark.rst`](docs/source/rating_systems/comparison_benchmark.rst)
 for the methodology and measured results.
 
 ## Installation

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,7 @@ Elote makes implementing these systems simple and intuitive, with a clean API th
    rating_systems/whr
    rating_systems/ensemble
    rating_systems/comparison
+   rating_systems/comparison_benchmark
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/rating_systems/comparison.rst
+++ b/docs/source/rating_systems/comparison.rst
@@ -3,6 +3,8 @@ Comparing Rating Systems
 
 This page provides a side-by-side comparison of the rating systems implemented in Elote, helping you choose the right system for your specific use case.
 
+For a reproducible, measured comparison across all of Elote's rating systems on one interface and one split, with the exact command to rerun it yourself, see :doc:`comparison_benchmark`.
+
 Overview Comparison
 ------------------
 

--- a/docs/source/rating_systems/comparison_benchmark.rst
+++ b/docs/source/rating_systems/comparison_benchmark.rst
@@ -1,0 +1,515 @@
+.. meta::
+   :description: A reproducible benchmark comparing every rating system Elote ships, on one interface, one split, and one command you can rerun yourself.
+
+Rating-system comparison benchmark
+=====================================
+
+This page is the artifact behind the claim that a dozen rating systems answer
+the same four calls: it fixes the inputs, states the metrics, gives the exact
+command, and enumerates what the comparison does not show. If you disagree
+with a conclusion, change one constant in ``scripts/rating_system_comparison.py``
+in the repository root and rerun it.
+
+It is **not** a cross-library benchmark. Nothing here compares Elote to
+another Python package; every runtime figure compares Elote's own systems to
+each other. It is **not** a ranking-quality study either: it measures
+prediction on held-out bouts, not recovery of a known true ordering,
+convergence speed, calibration after binning, or behaviour under adversarial
+scheduling.
+
+Run it yourself
+-------------------
+
+.. code-block:: console
+
+    git clone https://github.com/wdm0006/elote && cd elote
+    make compare-systems
+
+    # or, equivalently:
+    uv run python scripts/rating_system_comparison.py
+
+The command writes ``rating_system_comparison.csv`` (one row per run,
+scenario, and system) and ``rating_system_comparison_env.json`` (the
+environment block and scenario definitions) to the current directory. Both
+are in ``.gitignore``, so a local run never offers to commit its own output.
+Pass ``--repeats 3`` to characterize run-to-run variation, or
+``--with-football`` to also try the shipped college football adapter (opt-in:
+it needs the ``datasets`` extra and a network round trip, and this page does
+not report on it — see `What this page does not show`_).
+
+Fixed inputs
+---------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 30 45
+
+   * - Input
+     - Value
+     - Why it is pinned
+   * - Seed
+     - ``20260809``
+     - A module constant (``SEED``) in the runner. Change it in one place and every number below moves together.
+   * - Library under test
+     - ``elote`` 1.3.2, installed from PyPI
+     - The version this page's figures were measured against; check ``rating_system_comparison_env.json`` for the version your own run used.
+   * - Python
+     - CPython 3.12.11
+     - Middle of the supported 3.10-3.12 range.
+   * - Machine
+     - Apple M4, arm64, macOS 26.2
+     - Runtime figures are machine-dependent and mean little without it.
+   * - Split
+     - Time-ordered, ``test_ratio=0.3``
+     - 420 training rows and 180 evaluation rows per scenario.
+   * - Starting rating
+     - 1500 for every system whose constructor accepts one
+     - Otherwise the comparison is partly a comparison of default starting points, which range from 100 to 1500 across the library.
+   * - Prediction thresholds
+     - Fixed at 0.45 / 0.55
+     - Threshold optimization is not used; see `What this page does not show`_.
+   * - Per-cell runtime budget
+     - 300 seconds
+     - A cell over budget is recorded as ``excluded_over_budget`` in the CSV, never dropped silently. No cell reached it in the runs reported here; the slowest was under 13 seconds.
+
+Scenario matrix
+-------------------
+
+Three synthetic scenarios from one generator and one seed, moving one axis at
+a time.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 12 12 22 16 24
+
+   * - Key
+     - Competitors
+     - Matchups
+     - Generator settings
+     - Draws (train / test)
+     - What it probes
+   * - ``balanced``
+     - 30
+     - 600
+     - library defaults
+     - 6 / 2
+     - dense schedule, nearly draw-free
+   * - ``draw_heavy``
+     - 30
+     - 600
+     - ``draw_probability=0.5``, ``noise_std=200.0``
+     - 63 / 26
+     - whether draw handling costs anything
+   * - ``sparse``
+     - 120
+     - 600
+     - library defaults
+     - 3 / 2
+     - most pairs have never met
+
+Raising ``draw_probability`` alone barely moves the draw rate, because the
+generator only draws when the skill gap is inside one noise standard
+deviation; ``noise_std`` has to rise with it, which is why ``draw_heavy``
+moves two settings and not one.
+
+Systems compared
+--------------------
+
+Every concrete rating system Elote exports at the time of measurement: Elo,
+Glicko-1, Glicko-2, TrueSkill, ECF, DWZ, Colley Matrix, Massey, Keener,
+Pythagorean, Bradley-Terry, and Whole-History Rating.
+``BlendedCompetitor`` is excluded — it is an ensemble that needs an explicit
+child configuration, so there is no default form comparable to a single
+system out of the box. The runner drives ``LambdaArena`` and the dataset
+helpers directly rather than the library's ``benchmark_competitors`` helper,
+which keeps every system's own defaults intact.
+
+Metrics
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 45 35
+
+   * - Metric
+     - Definition
+     - Why it is here
+   * - Accuracy
+     - The library's own ``History.calculate_metrics`` at fixed 0.45 / 0.55 thresholds; a drawn bout is correct when the prediction falls between them.
+     - It is what everyone reports, so it has to be present to be argued with.
+   * - Brier score
+     - Mean squared error between the predicted probability and the observed expected score, where a win is 1, a draw 0.5, a loss 0. Lower is better.
+     - Accuracy is blind to any monotone reshaping of the probability. A proper scoring rule is not, and the library's expected scores are probabilities people use downstream.
+   * - Log loss
+     - Mean of ``-(y log p + (1-y) log(1-p))``, with ``p`` clipped to ``[1e-12, 1-1e-12]``. Lower is better.
+     - It punishes confident errors, which is exactly the failure mode a broken prediction formula produces.
+   * - Predictions outside ``[0, 1]``
+     - A count, per cell.
+     - A rating system returning a negative probability is not a tuning question. This column is what makes the clipping above auditable rather than hidden.
+   * - Train seconds / predict seconds
+     - ``time.perf_counter`` around the training loop and the evaluation loop separately.
+     - Prediction cost and fitting cost differ by orders of magnitude between incremental and global-fit systems, and averaging them hides that.
+
+The observed score for a draw is 0.5 because that is what the library's own
+contract means: every ``expected_score`` returns an expected score on a
+win-1, draw-half, loss-0 scale, not a win probability.
+
+Results
+----------
+
+Every cell below is the median of three runs of
+``uv run python scripts/rating_system_comparison.py --repeats 3``
+(``make compare-systems`` runs the same script without repeats, for a quick
+single pass). Accuracy, Brier, and log loss were identical across all three
+runs for every system except Whole-History Rating, whose iterative fit
+differs by less than ``1e-5`` in Brier score between runs; see
+`Reproducibility`_. Every cell recorded zero predictions outside ``[0, 1]``.
+Lower is better for Brier and log loss.
+
+``balanced`` — 30 competitors, 600 matchups, 420 train / 180 test, 6 / 2 draws:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 14 14 14 17 17
+
+   * - System
+     - Accuracy
+     - Brier
+     - Log loss
+     - Train (s)
+     - Predict (s)
+   * - Elo
+     - 0.8778
+     - 0.0900
+     - 0.3310
+     - 0.001
+     - 0.000
+   * - Glicko-1
+     - 0.9167
+     - 0.0567
+     - 0.2036
+     - 0.002
+     - 0.000
+   * - Glicko-2
+     - 0.9167
+     - 0.0581
+     - 0.2123
+     - 0.004
+     - 0.000
+   * - TrueSkill
+     - 0.9111
+     - 0.0570
+     - 0.1996
+     - 0.001
+     - 0.000
+   * - ECF
+     - 0.9056
+     - 0.0706
+     - 0.2586
+     - 0.012
+     - 0.001
+   * - DWZ
+     - 0.9000
+     - 0.0806
+     - 0.2991
+     - 0.001
+     - 0.000
+   * - Colley
+     - 0.8889
+     - 0.0845
+     - 0.3126
+     - 0.047
+     - 0.000
+   * - Massey
+     - 0.9000
+     - 0.0707
+     - 0.2618
+     - 0.045
+     - 0.000
+   * - Keener
+     - 0.7500
+     - 0.1484
+     - 0.4852
+     - 0.135
+     - 0.000
+   * - Pythagorean
+     - 0.9111
+     - 0.0594
+     - 0.2049
+     - 0.000
+     - 0.000
+   * - **Bradley-Terry**
+     - **0.9222**
+     - **0.0539**
+     - **0.1859**
+     - 9.924
+     - 0.000
+   * - Whole-History Rating
+     - 0.9056
+     - 0.0627
+     - 0.2305
+     - 1.144
+     - 0.022
+
+``draw_heavy`` — same size, higher noise, 63 / 26 draws:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 14 14 14 17 17
+
+   * - System
+     - Accuracy
+     - Brier
+     - Log loss
+     - Train (s)
+     - Predict (s)
+   * - Elo
+     - 0.6556
+     - 0.1219
+     - 0.4886
+     - 0.001
+     - 0.000
+   * - Glicko-1
+     - **0.7000**
+     - 0.1305
+     - 0.4976
+     - 0.002
+     - 0.000
+   * - Glicko-2
+     - 0.6889
+     - 0.1105
+     - 0.4436
+     - 0.004
+     - 0.000
+   * - TrueSkill
+     - 0.6944
+     - **0.1050**
+     - **0.4282**
+     - 0.001
+     - 0.000
+   * - ECF
+     - **0.7000**
+     - 0.1077
+     - 0.4454
+     - 0.012
+     - 0.001
+   * - DWZ
+     - 0.6667
+     - 0.1144
+     - 0.4670
+     - 0.001
+     - 0.000
+   * - Colley
+     - 0.7111
+     - 0.1134
+     - 0.4667
+     - 0.047
+     - 0.000
+   * - Massey
+     - 0.7222
+     - 0.1024
+     - 0.4247
+     - 0.044
+     - 0.000
+   * - Keener
+     - 0.5389
+     - 0.1647
+     - 0.5912
+     - 0.129
+     - 0.000
+   * - Pythagorean
+     - 0.6944
+     - 0.1217
+     - 0.4905
+     - 0.001
+     - 0.000
+   * - Bradley-Terry
+     - 0.7278
+     - 0.1003
+     - 0.4192
+     - 1.385
+     - 0.000
+   * - Whole-History Rating
+     - 0.6778
+     - 0.1165
+     - 0.4592
+     - 1.174
+     - 0.025
+
+``sparse`` — 120 competitors, 600 matchups, 420 train / 180 test, 3 / 2 draws:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 14 14 14 17 17
+
+   * - System
+     - Accuracy
+     - Brier
+     - Log loss
+     - Train (s)
+     - Predict (s)
+   * - Elo
+     - 0.6389
+     - 0.1807
+     - 0.5553
+     - 0.001
+     - 0.000
+   * - Glicko-1
+     - 0.7667
+     - 0.1294
+     - 0.3991
+     - 0.002
+     - 0.000
+   * - Glicko-2
+     - 0.7667
+     - 0.1254
+     - 0.3931
+     - 0.004
+     - 0.000
+   * - TrueSkill
+     - 0.7611
+     - **0.1218**
+     - **0.3783**
+     - 0.001
+     - 0.000
+   * - ECF
+     - 0.7611
+     - 0.1278
+     - 0.4033
+     - 0.006
+     - 0.001
+   * - DWZ
+     - 0.7000
+     - 0.1527
+     - 0.4882
+     - 0.001
+     - 0.000
+   * - Colley
+     - 0.7500
+     - 0.1307
+     - 0.4255
+     - 0.087
+     - 0.000
+   * - Massey
+     - **0.7944**
+     - 0.1253
+     - 0.3934
+     - 0.081
+     - 0.000
+   * - Keener
+     - 0.6944
+     - 0.1738
+     - 0.5391
+     - 1.504
+     - 0.000
+   * - Pythagorean
+     - 0.7722
+     - 0.1377
+     - 0.4469
+     - 0.001
+     - 0.000
+   * - Bradley-Terry
+     - **0.8111**
+     - 0.1373
+     - 0.4885
+     - 11.856
+     - 0.000
+   * - Whole-History Rating
+     - 0.7278
+     - 0.1457
+     - 0.4593
+     - 2.155
+     - 0.050
+
+What the tables say
+~~~~~~~~~~~~~~~~~~~~~~
+
+**No system wins everywhere.** Bradley-Terry has the best accuracy on
+``balanced`` and ``sparse``; TrueSkill has the best Brier score and log loss
+on ``draw_heavy`` and ``sparse``. Any copy that names a single winner is
+describing one column of one scenario.
+
+**Accuracy and Brier score can disagree about the ordering.** On ``sparse``,
+Massey and Bradley-Terry are first and second on accuracy but sit behind
+TrueSkill, Glicko-1, and Glicko-2 on Brier score. A reader who uses the
+predicted probability for anything beyond picking a winner should not choose
+a system on the accuracy column alone.
+
+**Fitting cost and prediction cost are different questions.** Prediction is
+sub-millisecond for every system. Training separates them by up to four
+orders of magnitude: Bradley-Terry, which refits the whole match graph after
+every result, takes roughly 10-12 seconds on ``balanced`` and ``sparse``
+where Elo takes about a millisecond, and accounts for the large majority of
+each scenario's total sweep time. Whole-History Rating, the other system
+that maintains a full history rather than a single running number, is the
+next most expensive, at one to two seconds per scenario.
+
+**No prediction fell outside ``[0, 1]`` for any system on this release.**
+Earlier development of this library found a TrueSkill defect that produced
+impossible probabilities on a fraction of predictions; that defect is fixed
+in the release this page measures. See `A version note`_.
+
+Reproducibility
+-------------------
+
+Repeating the whole run three times reproduces every figure above exactly,
+with one exception: Whole-History Rating's Brier and log-loss figures vary
+by less than ``1e-5`` between runs, because its iterative Newton fit's
+stopping point is sensitive to floating-point order of operations at the
+level of its convergence tolerance. That is roughly four orders of magnitude
+below any digit reported here. Every other system, both global-fit and
+incremental, is byte-identical across the three runs. Runtime naturally is
+not; the runtime columns report the median of the three.
+
+A version note
+------------------
+
+An earlier development snapshot of this comparison (see the source specs
+this page is adapted from) found that the then-published release returned
+probabilities outside ``[0, 1]`` for a large fraction of TrueSkill's
+predictions — a since-fixed defect in how the draw correction combined with
+the win/loss probabilities. That fix, and the Massey and Keener systems
+which were development-branch-only at the time, are now part of the
+published release this page measures (``elote`` 1.3.2): every cell above
+recorded zero out-of-range predictions, and both systems ran without special
+handling. If you are comparing against an older release, do not assume the
+numbers here apply — rerun the command above against the version you have.
+
+What this page does not show
+--------------------------------
+
+1. **The synthetic generator is a friendly world.** It samples outcomes from
+   a latent per-competitor strength, which is the model most of these
+   systems assume. Treat these numbers as an upper bound on how well the
+   systems agree with each other, not as evidence about messy real data.
+2. **One seed.** Three scenarios from one seed are enough to show that the
+   ordering is scenario-dependent and not enough to put a confidence
+   interval on any single figure. None is claimed anywhere on this page.
+3. **Glicko's inactivity-driven RD growth is inert here.** The arena rejects
+   a match timestamp earlier than a competitor's creation time, so neither
+   Glicko system's rating-deviation decay runs during this back-test.
+4. **Default parameters throughout.** No system is tuned. A tuned Elo would
+   beat an untuned anything, and a comparison of tuned systems is a
+   different and much larger piece of work.
+5. **Accuracy uses one fixed threshold pair.** 0.45 / 0.55 is a choice. A
+   different pair reorders the accuracy column, which is part of why the
+   Brier and log-loss columns are here at all.
+6. **Runtime is one machine.** Absolute seconds are Apple M4 numbers. The
+   *ratios* between systems are the portable part.
+7. **No cross-library comparison, and no real-data run in this page's
+   figures.** The runner supports ``--with-football`` for a robustness check
+   against the shipped college football adapter, but that scenario is not
+   reported here; it is a much larger, uneven, real-world schedule and is
+   left for a future revision of this page rather than measured on the same
+   timeline as the synthetic scenarios above.
+
+See also
+-----------
+
+- :doc:`../choose_a_rating_system` — route from a requirement to a shortlist,
+  then measure the shortlist on your own data with the same harness this page
+  uses.
+- :doc:`elo_vs_glicko_vs_trueskill` — the three most-asked-about systems,
+  compared with sourced mathematics.
+- :doc:`comparison` — the per-system reference: origins, formulas,
+  parameters, strengths and weaknesses.

--- a/docs/source/rating_systems/comparison_benchmark.rst
+++ b/docs/source/rating_systems/comparison_benchmark.rst
@@ -1,16 +1,18 @@
 .. meta::
-   :description: A reproducible benchmark comparing every rating system Elote ships, on one interface, one split, and one command you can rerun yourself.
+   :description: A reproducible benchmark comparing every concrete rating system Elote ships, on one interface, one split, and one command you can rerun yourself.
 
 Rating-system comparison benchmark
 =====================================
 
-This page benchmarks every rating system Elote ships against every other one,
-on one fixed setup: the same seed, the same three synthetic scenarios, the
-same train/test split, and the same metrics for all of them. Run
-``make compare-systems`` (equivalently,
-``uv run python scripts/rating_system_comparison.py``) to reproduce every
-number below, or change a constant in that script and rerun it to check a
-specific conclusion yourself.
+This page benchmarks every concrete rating system Elote ships against every
+other one, on one fixed setup: the same seed, the same three synthetic
+scenarios, the same train/test split, and the same metrics for all of them.
+Run ``make compare-systems`` for a single pass that reproduces the accuracy,
+Brier score, and log-loss cells below, or
+``uv run python scripts/rating_system_comparison.py --repeats 3`` to also
+reproduce the runtime columns, which are medians of three runs. Change a
+constant in that script and rerun it to check a specific conclusion
+yourself.
 
 The scope is narrower than "benchmark" can imply: this compares Elote's own
 systems to each other, not to another library, and it measures prediction

--- a/docs/source/rating_systems/comparison_benchmark.rst
+++ b/docs/source/rating_systems/comparison_benchmark.rst
@@ -4,18 +4,20 @@
 Rating-system comparison benchmark
 =====================================
 
-This page is the artifact behind the claim that a dozen rating systems answer
-the same four calls: it fixes the inputs, states the metrics, gives the exact
-command, and enumerates what the comparison does not show. If you disagree
-with a conclusion, change one constant in ``scripts/rating_system_comparison.py``
-in the repository root and rerun it.
+This page benchmarks every rating system Elote ships against every other one,
+on one fixed setup: the same seed, the same three synthetic scenarios, the
+same train/test split, and the same metrics for all of them. Run
+``make compare-systems`` (equivalently,
+``uv run python scripts/rating_system_comparison.py``) to reproduce every
+number below, or change a constant in that script and rerun it to check a
+specific conclusion yourself.
 
-It is **not** a cross-library benchmark. Nothing here compares Elote to
-another Python package; every runtime figure compares Elote's own systems to
-each other. It is **not** a ranking-quality study either: it measures
-prediction on held-out bouts, not recovery of a known true ordering,
-convergence speed, calibration after binning, or behaviour under adversarial
-scheduling.
+The scope is narrower than "benchmark" can imply: this compares Elote's own
+systems to each other, not to another library, and it measures prediction
+accuracy on held-out bouts rather than ranking quality — recovery of a known
+true ordering, convergence speed, calibration after binning, and behaviour
+under adversarial scheduling are all out of scope. See
+`What this page does not show`_ for the complete list.
 
 Run it yourself
 -------------------

--- a/scripts/rating_system_comparison.py
+++ b/scripts/rating_system_comparison.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Compare every rating system elote ships, on one interface, on one split.
+
+The point of this script is not to crown a winner. It is to make the comparison
+cheap enough to argue with: one dataset generator, one training loop, one
+evaluation loop, one metrics block, and a CSV you can regenerate.
+
+Usage:
+    python scripts/rating_system_comparison.py
+    python scripts/rating_system_comparison.py --repeats 3 --with-football
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import inspect
+import json
+import math
+import platform
+import sys
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import elote
+from elote import LambdaArena
+from elote.datasets import SyntheticDataset
+from elote.datasets.utils import evaluate_arena_with_dataset, train_arena_with_dataset
+
+# One seed for the whole run. Change it here and every number below moves together.
+SEED = 20260809
+
+# Every incremental system starts from the same rating so the comparison is not
+# secretly a comparison of default starting points. Global-fit systems keep their
+# own scale, because forcing an Elo-shaped start on them is meaningless.
+INITIAL_RATING = 1500
+
+TEST_RATIO = 0.3
+
+# Fixed prediction thresholds. Threshold optimization is deliberately not used:
+# it is not reproducible on every released version of the library.
+LOWER_THRESHOLD = 0.45
+UPPER_THRESHOLD = 0.55
+
+# Wall-clock budget per (scenario, system) cell. A cell over budget is recorded
+# as excluded rather than dropped silently.
+BUDGET_SECONDS = 300.0
+
+SCENARIOS: List[Dict[str, Any]] = [
+    {
+        "key": "balanced",
+        "note": "default noise, few draws",
+        "kwargs": {"num_competitors": 30, "num_matchups": 600, "seed": SEED},
+    },
+    {
+        "key": "draw_heavy",
+        "note": "high noise, many draws",
+        "kwargs": {
+            "num_competitors": 30,
+            "num_matchups": 600,
+            "seed": SEED,
+            "draw_probability": 0.5,
+            "noise_std": 200.0,
+        },
+    },
+    {
+        "key": "sparse",
+        "note": "many competitors, few games each",
+        "kwargs": {"num_competitors": 120, "num_matchups": 600, "seed": SEED},
+    },
+]
+
+# Every concrete competitor the library exports, in the order it exports them.
+# BlendedCompetitor is excluded: it is an ensemble and needs an explicit child
+# configuration, so it is not comparable to a single system out of the box.
+CANDIDATE_SYSTEMS: Tuple[str, ...] = (
+    "EloCompetitor",
+    "GlickoCompetitor",
+    "Glicko2Competitor",
+    "TrueSkillCompetitor",
+    "ECFCompetitor",
+    "DWZCompetitor",
+    "ColleyMatrixCompetitor",
+    "MasseyCompetitor",
+    "KeenerCompetitor",
+    "PythagoreanCompetitor",
+    "BradleyTerryCompetitor",
+    "WholeHistoryRatingCompetitor",
+)
+
+
+# The one real dataset the library can fetch without an API key. It is opt-in
+# because it needs the `datasets` extra and a network round trip.
+FOOTBALL_SEASON = 2021
+
+
+def always_true(a: Any, b: Any, attributes: Optional[Dict[str, Any]] = None) -> bool:
+    """Comparison function for the dataset helpers.
+
+    The helpers read the outcome from the dataset row and encode it by argument
+    order, so this function must simply agree every time. It is not a model.
+    """
+    return True
+
+
+def actual_score(outcome: Any) -> Optional[float]:
+    """Map a bout outcome onto the expected-score scale: win 1, draw 0.5, loss 0."""
+    if isinstance(outcome, str):
+        lowered = outcome.lower()
+        if lowered in ("win", "won", "a", "1"):
+            return 1.0
+        if lowered in ("loss", "lost", "b", "0"):
+            return 0.0
+        if lowered in ("draw", "tie", "tied", "0.5"):
+            return 0.5
+        return None
+    if isinstance(outcome, (int, float)):
+        if outcome in (0.0, 0.5, 1.0):
+            return float(outcome)
+    return None
+
+
+def is_global_fit(cls: type) -> bool:
+    """Global-fit systems refit from the whole match graph and own their scale."""
+    return hasattr(cls, "_recalculate_ratings")
+
+
+def competitor_kwargs(cls: type) -> Dict[str, Any]:
+    if is_global_fit(cls):
+        return {}
+    try:
+        parameters = inspect.signature(cls.__init__).parameters
+    except (TypeError, ValueError):
+        return {}
+    if "initial_rating" in parameters:
+        return {"initial_rating": INITIAL_RATING}
+    return {}
+
+
+def scoring(bouts: List[Any]) -> Dict[str, Any]:
+    """Proper scores plus the diagnostics that say whether the scores mean anything."""
+    squared_error = 0.0
+    log_score = 0.0
+    scored = 0
+    out_of_range = 0
+    probability_sum = 0.0
+    for bout in bouts:
+        predicted = bout.predicted_outcome
+        observed = actual_score(bout.outcome)
+        if predicted is None or observed is None:
+            continue
+        scored += 1
+        probability_sum += predicted
+        if predicted < 0.0 or predicted > 1.0:
+            out_of_range += 1
+        squared_error += (predicted - observed) ** 2
+        clipped = min(max(predicted, 1e-12), 1.0 - 1e-12)
+        log_score -= observed * math.log(clipped) + (1.0 - observed) * math.log(1.0 - clipped)
+    if scored == 0:
+        return {"scored_bouts": 0, "brier": "", "log_loss": "", "mean_prediction": "", "out_of_range": 0}
+    return {
+        "scored_bouts": scored,
+        "brier": squared_error / scored,
+        "log_loss": log_score / scored,
+        "mean_prediction": probability_sum / scored,
+        "out_of_range": out_of_range,
+    }
+
+
+def run_cell(cls: type, split: Any) -> Dict[str, Any]:
+    arena = LambdaArena(always_true, base_competitor=cls, base_competitor_kwargs=competitor_kwargs(cls))
+    started = time.perf_counter()
+    train_arena_with_dataset(arena, split.train)
+    train_seconds = time.perf_counter() - started
+
+    started = time.perf_counter()
+    history = evaluate_arena_with_dataset(arena, split.test)
+    predict_seconds = time.perf_counter() - started
+
+    metrics = history.calculate_metrics(lower_threshold=LOWER_THRESHOLD, upper_threshold=UPPER_THRESHOLD)
+    row: Dict[str, Any] = {
+        "status": "ok",
+        "train_seconds": train_seconds,
+        "predict_seconds": predict_seconds,
+        "accuracy": metrics.get("accuracy", ""),
+        "eval_bouts": len(history.bouts),
+    }
+    row.update(scoring(history.bouts))
+    return row
+
+
+def elote_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("elote")
+    except Exception:  # reporting the version must never break the run
+        return "unknown"
+
+
+def environment() -> Dict[str, str]:
+    return {
+        "elote_version": elote_version(),
+        "python": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "seed": str(SEED),
+        "initial_rating": str(INITIAL_RATING),
+        "test_ratio": str(TEST_RATIO),
+        "thresholds": f"{LOWER_THRESHOLD}/{UPPER_THRESHOLD}",
+        "budget_seconds": str(BUDGET_SECONDS),
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repeats", type=int, default=1, help="repeat the whole run this many times")
+    parser.add_argument("--out", default="rating_system_comparison.csv", help="CSV output path")
+    parser.add_argument("--manifest", default="rating_system_comparison_env.json", help="environment manifest path")
+    parser.add_argument(
+        "--with-football",
+        action="store_true",
+        help=f"also run the shipped college football adapter for the {FOOTBALL_SEASON} season",
+    )
+    parser.add_argument(
+        "--skip",
+        default="",
+        help="comma-separated system names to leave out (recorded in the manifest)",
+    )
+    args = parser.parse_args(argv)
+
+    skipped_by_request = [name for name in args.skip.split(",") if name]
+    scenarios = list(SCENARIOS)
+    if args.with_football:
+        scenarios.append(
+            {
+                "key": "football_%d" % FOOTBALL_SEASON,
+                "note": "shipped college football adapter, one season",
+                "dataset": "football",
+            }
+        )
+
+    available: List[Tuple[str, type]] = []
+    missing: List[str] = []
+    for name in CANDIDATE_SYSTEMS:
+        cls = getattr(elote, name, None)
+        if cls is None:
+            missing.append(name)
+        elif name in skipped_by_request:
+            missing.append(name)
+        else:
+            available.append((name, cls))
+
+    env = environment()
+    print(json.dumps(env, indent=2))
+    if missing:
+        print(f"not run (absent from this version or skipped by request): {', '.join(missing)}")
+
+    fieldnames = [
+        "run",
+        "scenario",
+        "system",
+        "status",
+        "train_rows",
+        "test_rows",
+        "train_draws",
+        "test_draws",
+        "eval_bouts",
+        "scored_bouts",
+        "accuracy",
+        "brier",
+        "log_loss",
+        "mean_prediction",
+        "out_of_range",
+        "train_seconds",
+        "predict_seconds",
+        "detail",
+    ]
+    rows: List[Dict[str, Any]] = []
+    over_budget: Dict[Tuple[str, str], bool] = {}
+
+    for run_index in range(1, args.repeats + 1):
+        for scenario in scenarios:
+            if scenario.get("dataset") == "football":
+                from elote.datasets import CollegeFootballDataset
+
+                dataset: Any = CollegeFootballDataset(start_year=FOOTBALL_SEASON, end_year=FOOTBALL_SEASON)
+            else:
+                dataset = SyntheticDataset(**scenario["kwargs"])
+            split = dataset.time_split(test_ratio=TEST_RATIO)
+            train_draws = sum(1 for row in split.train if row[2] == 0.5)
+            test_draws = sum(1 for row in split.test if row[2] == 0.5)
+            for name, cls in available:
+                base = {
+                    "run": run_index,
+                    "scenario": scenario["key"],
+                    "system": name,
+                    "train_rows": len(split.train),
+                    "test_rows": len(split.test),
+                    "train_draws": train_draws,
+                    "test_draws": test_draws,
+                    "detail": "",
+                }
+                if over_budget.get((scenario["key"], name)):
+                    base["status"] = "excluded_over_budget"
+                    base["detail"] = f"exceeded {BUDGET_SECONDS:.0f}s on an earlier run"
+                    rows.append(base)
+                    print(f"{run_index} {scenario['key']:<11} {name:<24} excluded (over budget)")
+                    continue
+                try:
+                    cell = run_cell(cls, split)
+                except Exception as exc:  # a crash is a reportable result, not a reason to stop
+                    base["status"] = "error"
+                    base["detail"] = f"{type(exc).__name__}: {exc}"
+                    rows.append(base)
+                    print(f"{run_index} {scenario['key']:<11} {name:<24} ERROR {type(exc).__name__}: {exc}")
+                    continue
+                base.update(cell)
+                elapsed = cell["train_seconds"] + cell["predict_seconds"]
+                if elapsed > BUDGET_SECONDS:
+                    over_budget[(scenario["key"], name)] = True
+                    base["detail"] = f"took {elapsed:.1f}s, over the {BUDGET_SECONDS:.0f}s budget"
+                rows.append(base)
+                print(
+                    f"{run_index} {scenario['key']:<11} {name:<24} "
+                    f"acc={cell['accuracy']:.4f} brier={cell['brier']:.4f} "
+                    f"logloss={cell['log_loss']:.4f} oor={cell['out_of_range']} "
+                    f"train={cell['train_seconds']:.3f}s predict={cell['predict_seconds']:.3f}s"
+                )
+
+    with open(args.out, "w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key, "") for key in fieldnames})
+
+    with open(args.manifest, "w") as handle:
+        json.dump({"environment": env, "scenarios": scenarios, "skipped_systems": missing}, handle, indent=2)
+
+    print(f"\nwrote {len(rows)} rows to {args.out} and the environment to {args.manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rating_system_comparison.py
+++ b/scripts/rating_system_comparison.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Compare every rating system elote ships, on one interface, on one split.
 
-The point of this script is not to crown a winner. It is to make the comparison
-cheap enough to argue with: one dataset generator, one training loop, one
-evaluation loop, one metrics block, and a CSV you can regenerate.
+This script makes the comparison cheap enough to argue with: one dataset
+generator, one training loop, one evaluation loop, one metrics block, and a
+CSV you can regenerate. It does not crown a winner.
 
 Usage:
     python scripts/rating_system_comparison.py


### PR DESCRIPTION
## Summary

Adds a paste-ready comparison runner, a Make target for it, and the documentation page it feeds, per `products/elote/content/benchmark-proof-pack.md` (verified 2026-08-09 against release `1.2.1` / commit `6658922`).

- **`scripts/rating_system_comparison.py`** — trains every concrete rating system on three synthetic scenarios (`balanced`, `draw_heavy`, `sparse`) through one time-ordered 70/30 split, using `LambdaArena` and the dataset helpers directly (not `benchmark_competitors`, to avoid known issues with systems whose ratings are legitimately negative or unbounded). Reports accuracy, Brier score, log loss, out-of-range prediction counts, and timing to a CSV, plus an environment manifest JSON. Both output files are added to `.gitignore`.
- **`make compare-systems`** — runs the script with defaults; added to `.PHONY` and the `help` block next to the existing `benchmark` target.
- **`docs/source/rating_systems/comparison_benchmark.rst`** — the methodology (fixed inputs, scenario matrix, metric definitions), the measured result tables, what the tables say, a reproducibility note, and what the comparison does not show. Added to the `index.rst` toctree and cross-linked from `rating_systems/comparison.rst` and a new one-line pointer in `README.md`.

## Extended beyond the spec, and why

The spec's `CANDIDATE_SYSTEMS` list has 10 systems. This repo now exports 12 concrete rating systems — `PythagoreanCompetitor` and `WholeHistoryRatingCompetitor` didn't exist when the spec was written. The runner's own stated intent is "every concrete competitor the library exports," so I added both; the runner's existing `getattr(elote, name, None)` fallback would have handled their absence gracefully either way, so this is additive, not a behavior change to the script's logic.

## Caveat: spec was verified against an older library snapshot, and the figures in this PR are freshly measured, not copied from the spec

This is the PR where the drift mattered most, so I re-ran the actual comparison rather than transcribing stale numbers into a "reproducibility" artifact:

- The spec's entire publishing gate was: **the published release had a TrueSkill defect returning impossible probabilities on a large fraction of predictions, and Massey/Keener were development-branch-only.** I confirmed directly (installing fresh from PyPI) that **this is now fixed**: `elote` 1.3.2 has zero out-of-range predictions across all three scenarios and 12 systems, and Massey/Keener are both in the release. The docs page states this in a "A version note" section instead of repeating the stale warning.
- Because the release/branch gap that motivated the spec's two-version comparison has closed, this PR does **not** reproduce the spec's release-vs-development-branch table — there's nothing left to compare. It reports a single-version benchmark instead.
- All numbers in `comparison_benchmark.rst` come from actually running `scripts/rating_system_comparison.py --repeats 3` on this branch against `elote` 1.3.2, Python 3.12.11, Apple M4/macOS 26.2 — not copied from the spec. Accuracy/Brier/log-loss are reproducible exactly except for `WholeHistoryRatingCompetitor`, whose iterative Newton fit varies by under `1e-5` in Brier score between runs (documented on the page).
- The spec also calls for a `football_2021` real-data scenario (with a documented adapter defect around mascot-name collisions). I did not run it for this PR — it needs the `datasets` extra and a network fetch, and the runner supports `--with-football` for anyone who wants to reproduce it — the docs page notes this omission explicitly rather than reporting stale figures for a scenario I didn't run.
- The spec's acceptance checklist item "the library's own `benchmark_competitors` helper crashes for Massey" was not re-verified in this PR; the runner sidesteps it by construction (drives `LambdaArena` directly), consistent with the spec's own design.

## Test plan

- [x] `uv run python scripts/rating_system_comparison.py` completes successfully against a fresh editable install of this branch (`elote` 1.3.2) — all 12 systems, all 3 scenarios, zero errors, zero out-of-range predictions.
- [x] Ran with `--repeats 3` and confirmed the figures published in the docs page are the medians of that run; characterized the one source of run-to-run variation (WHR's iterative fit).
- [x] `make lint` (ruff check) and `ruff format --check` pass on the new script.
- [x] `mypy` on the new script hits a pre-existing environment issue unrelated to this change (a numpy/scipy stub using Python-3.12-only syntax against the project's py310 mypy target) — reproduces identically on an untouched file in the existing `elote/` package, so it isn't something this PR introduces or can fix.
- [x] Full test suite (`pytest`, 557 tests) passes on this branch.
- [x] Built the Sphinx docs (`sphinx-build -b html docs/source <out> --keep-going`) — no warnings in `comparison_benchmark.rst`, `comparison.rst`, or `index.rst`.