### PR TITLE
Route period-native walk-forward training through rating periods

### DIFF
--- a/elote/evaluation.py
+++ b/elote/evaluation.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 
 from elote.arenas.lambda_arena import LambdaArena
 from elote.competitors.base import BaseCompetitor, InvalidParameterException
-from elote.datasets.utils import train_arena_with_dataset
+from elote.datasets.utils import _scores_from_attributes, train_arena_with_dataset
 from elote.logging import logger
 
 __all__ = ["WalkForwardReport", "TuningResult", "group_by_period", "walk_forward", "tune"]
@@ -144,6 +144,13 @@ def walk_forward(
 ) -> WalkForwardReport:
     """Predict each period from everything before it, then learn that period.
 
+    Systems that override :meth:`BaseCompetitor.apply_rating_period` learn through
+    :meth:`LambdaArena.rating_period`; systems that inherit the default implementation keep
+    the existing sequential dataset-training path. A period-native system receives the
+    maximum usable row timestamp as ``period_end`` (or ``None`` when there is none), so time
+    is resolved per period rather than per row. Sequential systems continue to receive each
+    row's timestamp individually.
+
     Args:
         competitor_class: The rating system to evaluate.
         periods: Ordered periods of dataset rows, as produced by :func:`group_by_period`.
@@ -216,7 +223,21 @@ def walk_forward(
                     log_loss_total -= actual * math.log(probability) + (1.0 - actual) * math.log(1.0 - probability)
                     brier_total += (probability - actual) ** 2
 
-            train_arena_with_dataset(arena, list(period), score_keys=score_keys)
+            if competitor_class.apply_rating_period.__func__ is BaseCompetitor.apply_rating_period.__func__:
+                train_arena_with_dataset(arena, list(period), score_keys=score_keys)
+            else:
+                period_rows = [
+                    (
+                        a,
+                        b,
+                        outcome,
+                        None if score_keys is None else _scores_from_attributes(attributes, score_keys),
+                    )
+                    for a, b, outcome, _when, attributes in period
+                    if outcome is not None
+                ]
+                timestamps = [when for _a, _b, _outcome, when, _attributes in period if isinstance(when, datetime)]
+                arena.rating_period(period_rows, period_end=max(timestamps, default=None))
 
             if scored and period_count:
                 by_period.append((index, period_count, period_correct / period_count))

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from elote import (
     EloCompetitor,
+    GlickoCompetitor,
     PythagoreanCompetitor,
     WholeHistoryRatingCompetitor,
     group_by_period,
@@ -39,6 +40,24 @@ def _season(weeks=6, teams=("A", "B", "C", "D")):
     return periods
 
 
+class PeriodNativeCompetitor(EloCompetitor):
+    period_calls = []
+    pairwise_calls = 0
+
+    def beat(self, competitor, *, scores=None):
+        type(self).pairwise_calls += 1
+        raise AssertionError("period-native training must not replay pairwise results")
+
+    @classmethod
+    def apply_rating_period(cls, results, period_end=None):
+        cls.period_calls.append((list(results), period_end))
+
+    @classmethod
+    def reset_calls(cls):
+        cls.period_calls = []
+        cls.pairwise_calls = 0
+
+
 class TestGroupByPeriod(unittest.TestCase):
     def test_groups_by_iso_week_in_order(self):
         rows = [
@@ -67,6 +86,9 @@ class TestGroupByPeriod(unittest.TestCase):
 
 
 class TestWalkForward(unittest.TestCase):
+    def setUp(self):
+        PeriodNativeCompetitor.reset_calls()
+
     def test_learns_a_separable_schedule(self):
         report = walk_forward(EloCompetitor, _season(), warmup=1)
         self.assertGreater(report.predictions, 0)
@@ -149,6 +171,50 @@ class TestWalkForward(unittest.TestCase):
             walk_forward(EloCompetitor, periods, warmup=2)
         with self.assertRaises(ValueError):
             walk_forward(EloCompetitor, periods, warmup=-1)
+
+    def test_period_native_system_uses_one_batch_call_per_period(self):
+        periods = _season(weeks=3)
+
+        walk_forward(PeriodNativeCompetitor, periods, warmup=1)
+
+        self.assertEqual(len(PeriodNativeCompetitor.period_calls), 3)
+        self.assertEqual(PeriodNativeCompetitor.pairwise_calls, 0)
+        self.assertEqual(
+            [period_end for _results, period_end in PeriodNativeCompetitor.period_calls],
+            [period[0][3] for period in periods],
+        )
+
+    def test_period_native_system_receives_scores_in_caller_order(self):
+        period = [
+            _row("A", "B", 1.0, datetime.datetime(2020, 1, 6), (21, 7)),
+            _row("B", "A", 0.0, datetime.datetime(2020, 1, 7), (3, 10)),
+            _row("A", "B", None, datetime.datetime(2020, 1, 8), (0, 0)),
+        ]
+
+        walk_forward(
+            PeriodNativeCompetitor,
+            [period],
+            score_keys=("home_score", "away_score"),
+        )
+
+        results, period_end = PeriodNativeCompetitor.period_calls[0]
+        self.assertEqual([result[3] for result in results], [(21.0, 7.0), (3.0, 10.0)])
+        self.assertEqual(period_end, datetime.datetime(2020, 1, 8))
+
+    def test_period_native_system_accepts_a_period_without_timestamps(self):
+        walk_forward(PeriodNativeCompetitor, [[_row("A", "B", 1.0, None)]])
+
+        self.assertIsNone(PeriodNativeCompetitor.period_calls[0][1])
+
+    def test_sequential_system_metrics_remain_pinned(self):
+        expected = {
+            EloCompetitor: (1.0, 0.4189136689010337, 0.12106875000089291),
+            GlickoCompetitor: (1.0, 0.129799282281943, 0.02092450055008762),
+        }
+        for competitor_class, metrics in expected.items():
+            with self.subTest(competitor_class=competitor_class.__name__):
+                report = walk_forward(competitor_class, _season(), warmup=1)
+                self.assertEqual((report.accuracy, report.log_loss, report.brier), metrics)
 
 
 class TestTune(unittest.TestCase):


### PR DESCRIPTION
Closes #176

## Summary

- route walk-forward training through `LambdaArena.rating_period` only when the competitor class overrides `BaseCompetitor.apply_rating_period`
- preserve sequential dataset training, including row-resolution timestamps, for all currently shipped systems
- forward score pairs in dataset caller order, skip missing outcomes, and use the maximum usable timestamp as `period_end` for period-native systems
- pin exact Elo and Glicko metrics to guard the unchanged default path

## Verification

- `pytest -q --ignore=tests/test_examples.py` — 559 passed, 6 skipped
- `ruff check .` — passed
- `mypy elote` — passed
- routing mutation: forced the sequential branch for every class; `test_period_native_system_uses_one_batch_call_per_period` failed on the attempted pairwise replay
- timestamp mutation: replaced the computed maximum timestamp with `period_end=None`; `test_period_native_system_receives_scores_in_caller_order` failed its exact period-end assertion
- restored focused check: `pytest -q tests/test_evaluation.py` — 23 passed