### PR TITLE
Prepare the v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,86 @@
+v1.4.0
+======
+
+A new rating system, a uniform rating-period operation, and a reproducible cross-system comparison
+runner. Thirteen rating systems now ship, against twelve in v1.3.2.
+
+New rating systems
+
+ * Added `GlickoBoostCompetitor`, Glickman's Glicko-Boost extension of Glicko: it adds a
+   colour/first-mover advantage term, a boost that widens rating deviation for a competitor whose
+   period performance is far above what its rating predicted, and a between-period RD inflation that
+   grows with rating and inactivity. It is the first system Elote ships whose update is defined over
+   a rating period rather than over a single bout. `beat`, `lost_to` and `tied` route through
+   `apply_rating_period` as one-game periods, so there is exactly one copy of the mathematics
+   (#175, #178).
+   Two columns of the paper's own worked example are not reproducible from the formulas it
+   publishes, and Section 2.4 is ambiguous about whose ratings feed the boost z-score. Elote takes
+   the pre-period reading, the only one under which the paper's narrative holds; the deviations and
+   the sweep establishing them are recorded in the module docstring and in
+   `docs/source/rating_systems/glicko_boost.rst`, and the rest of the table is asserted as a
+   published oracle.
+ * `GlickoBoostCompetitor` is deliberately excluded from the comparison benchmark at
+   `docs/source/rating_systems/comparison_benchmark.rst`. That harness trains bout by bout on a
+   frozen split, so it would measure Glicko-Boost's one-game fallback rather than the system;
+   comparing it fairly needs a period-grouped protocol.
+
+New features
+
+ * Added a uniform rating-period operation. `BaseCompetitor.apply_rating_period(results,
+   period_end=None)` applies a batch of `(competitor_a, competitor_b, outcome, scores)` rows to a
+   whole population at once, and `LambdaArena.rating_period(results, period_end=None)` does the same
+   for arena identifiers, validating the batch atomically, recording every prediction from the
+   pre-period snapshot, then delegating one batch to the competitor class. The default
+   implementation replays the rows through the ordinary pairwise operations, so every existing
+   system gets the hook with no change to its numbers (#167).
+ * `BaseCompetitor` is now exported from the package root.
+ * `walk_forward` routes period-native systems through `apply_rating_period` instead of replaying a
+   period bout by bout, which is what a period-defined system's protocol actually is. This path is
+   reachable only for a class that overrides `apply_rating_period`; `GlickoBoostCompetitor` is the
+   only such class and is new in this release, so no existing user's numbers move (#177).
+ * Added `scripts/rating_system_comparison.py` and a `make compare-systems` target: a single-command
+   runner that trains every concrete rating system on the same seed, scenarios and split, and writes
+   accuracy, Brier score, log loss, out-of-range prediction counts, runtimes and an environment
+   manifest to CSV. The methodology and the measured results are documented at
+   `docs/source/rating_systems/comparison_benchmark.rst` (#171).
+
+Behaviour changes
+
+ * `walk_forward` and `tune` now reject a `competitor_params` name that is not an existing
+   underscored class variable, raising `InvalidParameterException` before any arena is built or any
+   grid point is evaluated. Such a name was previously set on the class, ignored by every instance,
+   and deleted, so a typo, or any constructor-only parameter, produced a clean-looking run and a
+   `tune` "best" value that meant nothing. Most competitor parameters are constructor-only
+   (`initial_rating`, `initial_rd`, `initial_mu`, WHR's `w2`/`max_iterations`/`precision`), so a
+   script that passed one of those through `competitor_params` now raises where it used to run.
+   Where a `_default_<name>` class variable exists the error names `default_<name>` as the tunable
+   spelling; otherwise it points at `base_competitor_kwargs` (#162, #168).
+
+Bug fixes
+
+ * `scores=` now accepts any non-boolean real number, including NumPy scalars such as `np.int64` and
+   `np.float32`, and normalizes the value to a built-in `float`. The gate previously admitted only
+   built-in `int`/`float`, so a score read straight out of a NumPy array or a pandas column was
+   rejected even though the dataset adapter's own extraction path already accepted it. `np.bool_`
+   and complex values are still rejected (#161, #165).
+ * `BlendedCompetitor.from_state` resolves sub-competitor class names through the competitor
+   registry rather than a hand-maintained type map. The map had fallen five classes behind, and its
+   restore path hardcoded `initial_rating`, so legacy blended state naming a newer system failed to
+   restore and TrueSkill failed even though it was in the map (#114, #164).
+
+Documentation
+
+ * Added a rating-system decision guide (`choose_a_rating_system`) and an Elo/Glicko/TrueSkill
+   comparison page (#170), a page recording where Elote's ratings agree with other libraries and
+   where they do not (`elote_vs_other_packages`, #174), and reworked the README around
+   cross-model comparison (#169).
+
+Known deviations
+
+ * `WholeHistoryRatingCompetitor` does not align with the `whr` reference package under the closest
+   exposed configuration (#173). This is unresolved and ships as a known deviation in v1.4.0; if you
+   need numbers that match that reference, track the issue.
+
 v1.3.2
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "elote"
-version = "1.3.2"
+version = "1.4.0"
 description = "Python module for rating bouts (like with Elo Rating)"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Closes #180

Release preparation only: `pyproject.toml` goes to `1.4.0` and `CHANGELOG.md` gains a `v1.4.0`
section. No code, no docs restructuring. The commit is exactly two files.

**Merging this publishes nothing.** `.github/workflows/pypi-publish.yml` fires on a *created GitHub
Release*, not on a pushed tag, so tagging `v1.4.0` and creating the Release remain a manual operator
step after this merges.

## Why minor, not patch

`GlickoBoostCompetitor` is a new rating system and `apply_rating_period` / `LambdaArena.rating_period`
is a new public method on every competitor. Both are backward compatible.

## Every PR in `eacb7ee..HEAD` accounted for

Described in the v1.4.0 section:

| PR | Where it lands in the section |
| --- | --- |
| #178 (with #175) | New rating systems — `GlickoBoostCompetitor`, its period-native update, the paper deviations, and the benchmark exclusion |
| #167 | New features — `BaseCompetitor.apply_rating_period` / `LambdaArena.rating_period`, plus the `BaseCompetitor` package-root export it added |
| #177 | New features — `walk_forward` routes period-native systems through rating periods |
| #171 | New features — `scripts/rating_system_comparison.py` and `make compare-systems` |
| #168 (with #162) | Behaviour changes — `walk_forward`/`tune` reject non-class-variable `competitor_params` |
| #165 (with #161) | Bug fixes — NumPy real scalars accepted in `scores=` |
| #164 (with #114) | Bug fixes — `BlendedCompetitor` legacy state through the competitor registry |
| #170, #174, #169 | Documentation |

Docs-only, confirmed with `git show --stat`:

- **#169** (`10b1476`) — `README.md` only.
- **#170** (`3aed53e`) — 18 files, all under `docs/source/`.
- **#174** (`17db378`) — `docs/source/index.rst` and one new page.

I gave those three a one-line **Documentation** group rather than omitting them silently, because
the decision guide and the cross-library page are user-facing enough that a reader of the release
notes should know they exist. #171 is *not* docs-only (it adds a script, a Makefile target and a
`.gitignore` entry), so it sits under New features.

## The two flagged decisions

- **#173** (WHR does not align with the `whr` reference) is still OPEN. Since resolving it is a
  numeric change and this PR is scoped to a version string and a changelog, I took the issue's
  other option: it ships as an explicit **Known deviations** bullet in the v1.4.0 section citing
  #173. If you would rather hold the release, that bullet is one line to drop once it lands.
- **#123** (Keener) is still OPEN and labelled `autopilot:approved` while `KeenerCompetitor` has
  shipped since v1.3.0. It looks stale and probably just wants closing. I did not touch it —
  that's your call, and it does not block this release.

## Verification

Everything below ran on this branch at `f1320e8`, in a `uv venv --python 3.12` + `uv sync --extra dev`
environment.

**Build and artifact metadata**

```
$ uv build --sdist
Building source distribution...
Successfully built dist/elote-1.4.0.tar.gz

$ tar -xzOf dist/elote-1.4.0.tar.gz 'elote-1.4.0/PKG-INFO' | grep -E '^(Name|Version):'
Name: elote
Version: 1.4.0
```

**The sdist installed into a throwaway venv and exercised from outside the checkout** (`uv build`
exits 0 on a distribution containing zero modules, so this is the check that actually proves the
artifact):

```
$ uv venv --python 3.12 /tmp/relvenv
$ uv pip install --python /tmp/relvenv/bin/python dist/elote-1.4.0.tar.gz
$ cd /tmp && /tmp/relvenv/bin/python -c "..."
version 1.4.0
path /tmp/relvenv/lib/python3.12/site-packages/elote/__init__.py
rating after beat 1583.7517 1416.2483
apply_rating_period on base? True
arena rating_period? True
```

`path` is under `site-packages`, not the working tree, and `elote.GlickoBoostCompetitor` both
imports and produces a real rating update.

**Full suite, as tox/CI runs it**

```
$ .venv/bin/python -m pytest -q tests
600 passed, 6 skipped, 2 warnings in 28.67s
```

**Lint**

```
$ make lint
All checks passed!
```

**Sphinx docs**

```
$ cd docs && sphinx-build -b html source /tmp/docsout
build succeeded, 537 warnings.
```

537 WARNING+ERROR lines, unchanged from master — this diff touches no `.rst` file and no docstring.
That count is the repo's existing docstring-style and `duplicate object description` baseline, and
the docs job is not `-W`.

**`uv.lock` is not in the commit.** `uv sync` / `uv run` / the docs build each rewrite it in the
worktree; I restored it before staging.

```
$ git show --stat HEAD
 CHANGELOG.md   | 83 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 pyproject.toml |  2 +-
 2 files changed, 84 insertions(+), 1 deletion(-)
```

Its `[[package]] name = "elote"` entry still reads `1.2.1`, which is already stale on master — the
v1.3.0, v1.3.1 and v1.3.2 release commits did not touch it either (`git log --oneline -- uv.lock`
last shows `9ec1482 Prepare v1.2.1 release`). Refreshing it is a real but separate change, and
doing it here would have pulled in unrelated resolver-marker churn from my local `uv`.


**No stale version string elsewhere in the tree.** `docs/source/conf.py` derives `release` from
`importlib.metadata.version("elote")`, and there is no `__version__` in `elote/__init__.py`, so
`pyproject.toml` remains the sole version source. The six remaining `1.3.2` occurrences are all in
`comparison_benchmark.rst` and `elote_vs_other_packages.rst`, where they record *which release a
measurement was taken against* — bumping those would falsely claim the numbers were re-measured on
1.4.0, so they are deliberately left alone. Nothing under `docs/source/` includes `CHANGELOG.md`, so
the new section is not an input to the Sphinx build and the unchanged 537-warning count holds.

All six CI checks are green on this branch: docs, lint, test, and test-matrix on 3.10 / 3.11 / 3.12.
