### PR TITLE
Let Glicko-1 and Glicko-2 lost_to record a match time

### DIFF
--- a/elote/competitors/glicko.py
+++ b/elote/competitors/glicko.py
@@ -338,6 +338,37 @@ class GlickoCompetitor(BaseCompetitor):
         logger.debug("%s beat %s (time=%s)", self, competitor, match_time)
         self._compute_match_result(competitor, s=1, match_time=match_time)
 
+    def lost_to(
+        self,
+        competitor: "GlickoCompetitor",
+        match_time: Optional[datetime] = None,
+        *,
+        scores: Optional[Sequence[float]] = None,
+    ) -> None:
+        """Update ratings after this competitor has lost to the given competitor.
+
+        This is a convenience method that calls :meth:`beat` on the winning competitor,
+        forwarding the match time so a loser-side result still records elapsed-time RD
+        inflation.
+
+        Args:
+            competitor (GlickoCompetitor): The opponent competitor that won.
+            match_time (datetime, optional): The time when the match occurred. Default: current time.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. They are reversed before being handed to
+                the winner's :meth:`beat`, so the caller never reorders them.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 0.0)
+        competitor.beat(
+            self,
+            match_time,
+            scores=None if validated is None else (validated[1], validated[0]),
+        )
+
     def tied(
         self,
         competitor: "GlickoCompetitor",

--- a/elote/competitors/glicko2.py
+++ b/elote/competitors/glicko2.py
@@ -698,6 +698,37 @@ class Glicko2Competitor(BaseCompetitor):
         logger.debug("%s beat %s (time=%s). Recording result.", self, competitor, match_time)
         self._compute_match_result(cast(Glicko2Competitor, competitor), s=1.0, match_time=match_time)
 
+    def lost_to(
+        self,
+        competitor: "Glicko2Competitor",
+        match_time: Optional[datetime] = None,
+        *,
+        scores: Optional[Sequence[float]] = None,
+    ) -> None:
+        """Update ratings after this competitor has lost to the given competitor.
+
+        This is a convenience method that calls :meth:`beat` on the winning competitor,
+        forwarding the match time so a loser-side result still records elapsed-time RD
+        inflation.
+
+        Args:
+            competitor (Glicko2Competitor): The opponent competitor that won.
+            match_time (datetime, optional): The time when the match occurred. Default: current time.
+            scores (sequence of float, optional): The two scores in caller order,
+                ``(self_score, competitor_score)``. They are reversed before being handed to
+                the winner's :meth:`beat`, so the caller never reorders them.
+
+        Raises:
+            MissMatchedCompetitorTypesException: If the competitor types don't match.
+        """
+        self.verify_competitor_types(competitor)
+        validated = self._validate_scores(scores, 0.0)
+        competitor.beat(
+            self,
+            match_time,
+            scores=None if validated is None else (validated[1], validated[0]),
+        )
+
     def tied(
         self,
         competitor: BaseCompetitor,

--- a/tests/test_glicko_historical_time.py
+++ b/tests/test_glicko_historical_time.py
@@ -173,5 +173,112 @@ class TestHistoricalStateRoundTrip(unittest.TestCase):
                 self.assertLessEqual(restored._last_activity, after)
 
 
+ANNUAL = (datetime(2020, 1, 1), datetime(2021, 1, 1), datetime(2022, 1, 1))
+
+
+def _record(competitor_class, times, method):
+    """Replay one annual sequence of decisive results, returning ``(winner, loser)``."""
+    winner, loser = competitor_class(), competitor_class()
+    for match_time in times:
+        if method == "beat":
+            winner.beat(loser, match_time=match_time)
+        elif method == "lost_to":
+            loser.lost_to(winner, match_time=match_time)
+        elif method == "beat_untimed":
+            winner.beat(loser)
+        else:
+            loser.lost_to(winner)
+    return winner, loser
+
+
+class TestTimedLostTo(unittest.TestCase):
+    """``lost_to`` must be able to express a match time, like ``beat`` and ``tied``."""
+
+    def test_timed_lost_to_matches_timed_beat(self):
+        """The same annual results recorded from the loser's side land on the same ratings."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                won_winner, won_loser = _record(competitor_class, ANNUAL, "beat")
+                lost_winner, lost_loser = _record(competitor_class, ANNUAL, "lost_to")
+
+                for label, expected, actual in (
+                    ("winner", won_winner, lost_winner),
+                    ("loser", won_loser, lost_loser),
+                ):
+                    self.assertAlmostEqual(actual.rating, expected.rating, delta=1e-9, msg=label)
+                    self.assertAlmostEqual(actual.rd, expected.rd, delta=1e-9, msg=label)
+
+    def test_timed_lost_to_records_the_supplied_match_time(self):
+        """Activity is stamped with the match time, not wall-clock now()."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                winner, loser = _record(competitor_class, ANNUAL, "lost_to")
+
+                for competitor in (winner, loser):
+                    self.assertEqual(competitor._last_activity, ANNUAL[-1])
+
+    def test_untimed_lost_to_is_unchanged(self):
+        """Omitting match_time keeps the previous, inflation-free numbers."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                beat_winner, beat_loser = _record(competitor_class, ANNUAL, "beat_untimed")
+                lost_winner, lost_loser = _record(competitor_class, ANNUAL, "lost_to_untimed")
+
+                # Both sides stamp wall-clock now(), so the tolerance allows for the RD that a
+                # slow replay accrues between calls; the pinned literals below are the real guard.
+                for expected, actual in ((beat_winner, lost_winner), (beat_loser, lost_loser)):
+                    self.assertAlmostEqual(actual.rating, expected.rating, delta=1e-6)
+                    self.assertAlmostEqual(actual.rd, expected.rd, delta=1e-6)
+
+        # Both fixtures are pinned outright, so a silent change to the untimed path shows up.
+        for competitor_class, expected in (
+            (GlickoCompetitor, (1752.744, 1247.256, 243.231)),
+            (Glicko2Competitor, (1752.967, 1247.033, 243.596)),
+        ):
+            with self.subTest(competitor=competitor_class.__name__):
+                winner, loser = _record(competitor_class, ANNUAL, "lost_to_untimed")
+                winner_rating, loser_rating, rd = expected
+
+                self.assertAlmostEqual(winner.rating, winner_rating, places=3)
+                self.assertAlmostEqual(loser.rating, loser_rating, places=3)
+                self.assertAlmostEqual(winner.rd, rd, places=3)
+                self.assertAlmostEqual(loser.rd, rd, places=3)
+
+    def test_out_of_order_timed_lost_to_still_raises(self):
+        """A timed loss dated before the competitor's last activity is still rejected."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                winner, loser = competitor_class(), competitor_class()
+                loser.lost_to(winner, match_time=datetime(2024, 6, 1))
+
+                with self.assertRaises(InvalidParameterException):
+                    loser.lost_to(winner, match_time=datetime(2024, 5, 31))
+
+    def test_scores_reverse_through_a_timed_lost_to(self):
+        """A losing score payload is reversed onto the winner's beat, with the time intact."""
+        match_time = datetime(2024, 6, 1)
+
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                lost_winner, lost_loser = competitor_class(), competitor_class()
+                lost_loser.lost_to(lost_winner, match_time=match_time, scores=(1, 3))
+
+                beat_winner, beat_loser = competitor_class(), competitor_class()
+                beat_winner.beat(beat_loser, match_time=match_time, scores=(3, 1))
+
+                for expected, actual in ((beat_winner, lost_winner), (beat_loser, lost_loser)):
+                    self.assertAlmostEqual(actual.rating, expected.rating, delta=1e-9)
+                    self.assertAlmostEqual(actual.rd, expected.rd, delta=1e-9)
+                    self.assertEqual(actual._last_activity, match_time)
+
+    def test_timed_lost_to_rejects_a_winning_score_payload(self):
+        """Score validation still runs on the loser's side of a timed result."""
+        for competitor_class in COMPETITOR_CLASSES:
+            with self.subTest(competitor=competitor_class.__name__):
+                winner, loser = competitor_class(), competitor_class()
+
+                with self.assertRaises(ValueError):
+                    loser.lost_to(winner, match_time=datetime(2024, 6, 1), scores=(3, 1))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #179

`GlickoCompetitor` and `Glicko2Competitor` defined time-aware `beat` and `tied` but inherited
`BaseCompetitor.lost_to`, which has no `match_time` parameter and forwards to
`competitor.beat(self, scores=...)` without one. So the two systems whose selling point is
elapsed-time RD inflation were the two that could not express a timestamp on the loser's side:
the timed call raised `TypeError`, and the only callable form stamped wall-clock `now()` and
applied no inactivity inflation.

## What changed

- `elote/competitors/glicko.py`, `elote/competitors/glicko2.py`: a `lost_to` override on each
  class, signature `(self, competitor, match_time=None, *, scores=None)` matching that class's own
  `beat`/`tied`. It keeps the existing score reversal and delegates to the winner's time-aware
  `beat`, so there is still exactly one copy of the update math. This mirrors the overrides
  `WholeHistoryRatingCompetitor` and `GlickoBoostCompetitor` already carry. The two classes are
  independent `BaseCompetitor` subclasses (`Glicko2Competitor` does not subclass
  `GlickoCompetitor`), so both copies are genuinely needed.
- `tests/test_glicko_historical_time.py`: six new tests in a `TestTimedLostTo` case, each looping
  over both classes.

`BaseCompetitor.lost_to`'s signature is deliberately unchanged — the eight score-only systems'
`beat` takes no `match_time`, so widening the base method would break them. `LambdaArena` and
`apply_rating_period`'s default replay are untouched; both dispatch a loss as the winner's `beat`,
which is why this hole was only reachable from direct competitor use. Routing them through
`lost_to` is now unblocked but is follow-up work, not this PR.

## Verification

Run in a `uv venv --python 3.12` + `uv sync --extra dev` env, all commands from the worktree root.

**Suite.** `env -u VIRTUAL_ENV .venv/bin/python -m pytest -q --ignore=tests/test_examples.py`
- Baseline at `7c63f55` (this branch's changes stashed): **598 passed, 6 skipped**
- With this branch: **604 passed, 6 skipped** (+6, the new tests)

No existing assertion needed changing; nothing in `tests/test_Glicko*.py` pinned the timeless
`lost_to`.

**`make lint`:** `All checks passed!` · **`make typecheck`:** `Success: no issues found in 30
source files`.

**Measured numbers.** The equivalence and the untimed literals were re-measured on this checkout
rather than transcribed. Three annual results (`2020-01-01`, `2021-01-01`, `2022-01-01`) from fresh
competitors:

| class | via | winner rating / rd | loser rating / rd |
|---|---|---|---|
| Glicko-1 | `beat(match_time=t)` | 1794.404 / 318.054 | 1205.596 / 318.054 |
| Glicko-1 | `lost_to(match_time=t)` | 1794.404 / 318.054 | 1205.596 / 318.054 |
| Glicko-1 | `lost_to()` untimed | 1752.744 / 243.231 | 1247.256 / 243.231 |
| Glicko-2 | `beat(match_time=t)` | 1794.521 / 318.189 | 1205.479 / 318.189 |
| Glicko-2 | `lost_to(match_time=t)` | 1794.521 / 318.189 | 1205.479 / 318.189 |
| Glicko-2 | `lost_to()` untimed | 1752.967 / 243.596 | 1247.033 / 243.596 |

The Glicko-1 figures reproduce the issue's exactly. `_last_activity` after the timed replay is
`2022-01-01`, not `now()`.

**Mutation checks.** Fix committed first, then mutated, `__pycache__` cleared, and each mutation
confirmed against what the interpreter actually imports (`inspect.getsource(cls.lost_to)`), not the
bytes on disk. Two mutations, run separately:

*1 — drop `match_time` from the forwarding call in both files* (`match_time forwarded: False` for
both classes):

```
FAILED tests/test_glicko_historical_time.py::TestTimedLostTo::test_out_of_order_timed_lost_to_still_raises
FAILED tests/test_glicko_historical_time.py::TestTimedLostTo::test_scores_reverse_through_a_timed_lost_to
FAILED tests/test_glicko_historical_time.py::TestTimedLostTo::test_timed_lost_to_matches_timed_beat
FAILED tests/test_glicko_historical_time.py::TestTimedLostTo::test_timed_lost_to_records_the_supplied_match_time
4 failed, 11 passed in 0.47s
```

**4 of the 6 new tests caught it**, each failing for both classes. The two that survive are the
ones that should: `test_untimed_lost_to_is_unchanged` (the untimed path is exactly what the
mutation reverts to) and `test_timed_lost_to_rejects_a_winning_score_payload` (validation, not
forwarding).

*2 — drop the score reversal* (`scores=validated` instead of the swapped pair, both files;
`reversal present: False`):

```
FAILED tests/test_glicko_historical_time.py::TestTimedLostTo::test_scores_reverse_through_a_timed_lost_to
1 failed, 14 passed in 0.50s
```

After restoring, the interpreter-level probe reported `True` for both classes on both mutation
sites and the full suite was green again at 604 passed.

**Which assertion carries what.** Glicko validates `scores` and then discards them — neither
`_compute_match_result` nor the Glicko-2 update reads the payload — so the score-reversal
criterion cannot be carried by a *rating* comparison. It is nonetheless caught, via validation
asymmetry: an unreversed `(1, 3)` reaches the winner's `beat`, whose `_validate_scores(scores,
1.0)` rejects it for not describing a win (mutation 2 above). `test_timed_lost_to_rejects_a_winning
_score_payload` covers the other direction, that `_validate_scores(scores, 0.0)` still runs on the
loser's side. The behaviour of the fix itself is carried by `test_timed_lost_to_matches_timed_beat`
and `test_timed_lost_to_records_the_supplied_match_time`. In
`test_untimed_lost_to_is_unchanged`, the untimed `beat`-vs-`lost_to` comparison is a control (both
stamp `now()`, so it is tolerance-bounded at 1e-6 rather than 1e-9); the pinned per-class literals
are what actually guard the untimed path.